### PR TITLE
0.5.0: training split, CPU prefill, supervised-training toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
       - run: cargo doc --no-deps --workspace
 
   msrv:
-    name: MSRV (1.94)
+    name: MSRV (1.97)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.97"
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94"
+          toolchain: "1.97"
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94"
+          toolchain: "1.97"
 
       - name: Verify tag matches Cargo.toml
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,137 @@
 # Changelog
 
+## 0.5.0 (unreleased)
+
+Feature release: the bring-your-own-loss training split, full-sequence
+CPU prefill, and the supervised-training toolkit (grad clipping, gradient
+accumulation, LR schedules, no-decay groups, trainable bf16/f16
+input_proj). All additive; the fused `step()` and every captured-graph
+path are byte-untouched (the split composes the exact eager phase bodies
+the fused step already ran -- pinned by bit-identity tests).
+
+MSRV 1.94 -> 1.97 (dev/CI toolchain 1.97.1 -- never 1.97.0, which carries
+an LLVM miscompilation). cudarc 0.19.8, safetensors 0.8, hf-hub 1.0,
+tokenizers 0.23.
+
+### Added: forward/backward split on both trainers
+
+`MambaTrainer::forward()` / `backward_step()` (and the `Mamba3Trainer`
+mirrors): `forward` returns the full `batch * seq_len * d_model`
+post-norm_f temporal output on the host (f32 on every dtype -- bf16/f16
+upcast on device before download), so a caller-side loss can run between
+the halves; `backward_step` backprops the caller's `d_temporal` through
+the saved activations and runs AdamW. `BackwardOpts` carries:
+
+- `clip_max_norm` -- `torch.nn.utils.clip_grad_norm_` semantics on a
+  DETERMINISTIC fixed-order f64 partials reduction (one new kernel,
+  `kernels/grad_clip.cu` -- the only new kernel in the release). For f16
+  the norm is computed after the unscale, per the
+  unscale-then-norm-then-clip ordering law.
+- `accumulate_only` -- exact gradient accumulation: the arena is not
+  zeroed, Adam does not advance, the optimizer tail is skipped. The
+  fused `step()` refuses while a window is open (it would zero the
+  arena and silently discard the accumulated gradients). Two accumulated
+  micro-batches reproduce the one-big-batch weights to <=1e-5 under the
+  batch-invariant flag.
+
+f16 rides the GradScaler protocol through the split (overflow skip, step
+rollback, scaler update); `accumulate_only` is rejected on f16 (the
+loss-scale freeze window across micro-batches has no defined semantics).
+`examples/custom_loss.rs` shows the full loop.
+
+### Added: full-sequence CPU prefill (both architectures)
+
+The CPU inference path was per-step matvec only -- a T-token prompt paid
+T dispatches and re-streamed every weight matrix T times.
+`forward_mamba_backbone_prefill(_mode)` and the M3 twin
+`forward_mamba3_backbone_prefill(_mode)` run the training forward's
+batched-SGEMM pipeline on inference types with no activation tape, write
+the post-norm_f output at EVERY position, and carry the recurrent state
+so the step path continues seamlessly (prefill-then-decode).
+`PrefillMode::Parallel` parallelizes every phase (GEMMs via the gemm
+crate's rayon parallelism, per-channel/per-head loops, transpose tiles)
+with no cross-task reductions -- bit-equal to `Single` by construction,
+and both bit-equal to the training forward (anchor tests pin all three
+across the {default, gemm-blas, accelerate} backends). Batch helpers
+`prefill_batch` / `prefill3_batch` parallelize per sample instead.
+`examples/cpu_prefill.rs` demonstrates prefill-then-decode and pooling.
+
+### Added: training-loop controls
+
+- `set_lr` / `lr` / `drop_graph` on both trainers. `set_lr` errs while a
+  captured graph exists -- the lr is baked BY VALUE into the captured
+  AdamW kernel and a bare field write would be a silent no-op under
+  replay; `drop_graph -> set_lr -> capture_graph` re-arms graph stepping.
+- `set_reference_no_decay(true)` -- the reference `_no_weight_decay`
+  parameter groups (M1: `a_log`, `D`, dt bias, every RMSNorm scale; M3:
+  dt bias, `D`, every norm scale) get `weight_decay = 0`, matching
+  upstream AdamW grouping. Default OFF preserves the historical
+  decay-everything behavior bit-for-bit.
+
+### Added: trainable input_proj in the mixed (bf16/f16) trainer
+
+The mixed trainer previously rejected a non-identity `input_proj`
+(HF-LM-shaped assumption). Both stubs are now filled -- typed forward
+GEMM with f32 bias + upcast into the residual stream; backward computes
+db (deterministic bias reduce) and dW (typed TN GEMM); dX below the
+projection is intentionally not produced (nothing upstream of the
+projection is trainable). Covered by the mixed parity walk (the
+input_proj skip is REMOVED), a rectangular split==fused bit-identity
+test, graph capture at a large patch dim, and batch-invariant probes.
+
+### Fixed: matvec_bi faulted on arbitrary K
+
+Pre-existing 0.4.x bug: `k_per_warp = ceil(K/8)` could be ODD (K=200 ->
+25), producing a misaligned paired `LDS.U32` smem read
+(`CUDA_ERROR_MISALIGNED_ADDRESS`); the vectorized `uint4` A-row load
+also assumed 16-byte row alignment, and a `__builtin_assume(K % 8 == 0)`
+was UB for most K. Historic HF d_models (768/1024/2048/2560) all
+produced even spans, masking it. Fixed: even per-warp span (existing
+shapes' reduction order untouched -- determinism suite bit-green),
+alignment-guarded vector loads, assume removed. Fresh-process per-K
+probes in `tests/matvec_probe.rs`.
+
+### Fixed / changed, smaller
+
+- Dead `da_exp` activation buffer removed from the GPU forward: kernels
+  never wrote it and backward recomputes the value -- ~0.9 GB/layer at
+  vision-class shapes (21.8 GB at d384x24 T=4617). Measured after
+  removal (bf16, 32 GB 5090, T=4617, input_dim=1024): B=1 = 9.6 GiB,
+  B=2 = 18.0 GiB, B=4 = OOM -> micro-batch 2 + accumulation.
+- f16 graph capture pre-sizes the input_dim-aware batch-invariant upcast
+  scratch (a lazy grow inside capture is illegal).
+- Stale `step()` rustdoc claimed `d_temporal` is `batch * d_model`; the
+  actual contract is `batch * seq_len * d_model` (fixed in all three
+  sites plus the M3 heavy-tail A comment block).
+- Slim GEMM geometry macros are `#undef`'d at the end of their section
+  (the 0.4.0 geometry-leak class cannot recur by appending kernels).
+- AdamW per-step pairs Vecs are pre-sized (no grow-reallocs per step).
+- f64 shadow-forward gradient oracle for the CPU training path
+  (`tests/grad_oracle.rs`) -- certifies every weight-tensor gradient
+  against an independent f64 recomputation, replacing noisy
+  finite-difference checks as the analytic reference.
+- docs.rs metadata: renders the CPU API surface (`hf`, `gemm-blas`,
+  `cli`); GPU doc-badge plumbing is a planned follow-up.
+
+### Named and deferred (post-0.5.0 tickets, each with a trigger)
+
+- int64 kernel offset arithmetic (upstream #880 class) -- index products
+  overflow i32 only beyond batch*T*d_inner*d_state > 2^31; trigger:
+  LLM-scale training shapes.
+- Device-side LR (capturable `set_lr` without graph re-capture);
+  captured-split package; device temporal handles / pooled readback --
+  trigger: profiling shows host readback dominating a real training loop.
+- GpuAdamW state export (warm optimizer resume) -- trigger: long
+  multi-session runs measurably suffering from cold Adam restarts.
+- `serialize` metadata for `rms_norm_eps` / `scan_mode` (additive) --
+  trigger: first non-default-eps deployment.
+- Selective-scan recomputation in backward (~4x activation memory cut) --
+  trigger: T >= 8k training or a hard single-pass B >= 4 need.
+- dX plumb-through below input_proj -- trigger: conv stem / learnable
+  pos-embed; per-block FFN channel mixer -- trigger: accuracy-lever
+  escalation on a real consumer.
+
+
 ## 0.4.2
 
 Performance update: the tensor-core deterministic tier gets a small-tile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0 (unreleased)
+## 0.5.0
 
 Feature release: the bring-your-own-loss training split, full-sequence
 CPU prefill, and the supervised-training toolkit (grad clipping, gradient

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,13 +1950,15 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "mamba-rs"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cudarc"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,12 +88,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,9 +95,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -125,30 +119,30 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -163,9 +157,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "castaway"
@@ -178,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -194,9 +188,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -204,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -216,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -240,9 +234,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -255,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -331,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -341,18 +335,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -406,18 +400,18 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -428,9 +422,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -486,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -522,9 +513,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -605,12 +596,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -874,22 +859,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -919,31 +902,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -983,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -993,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1003,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1022,9 +996,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1043,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1180,12 +1154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1219,16 +1187,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1242,16 +1208,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1276,27 +1232,20 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1316,9 +1265,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1343,9 +1292,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1384,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1412,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1482,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1520,9 +1469,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -1532,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1542,15 +1491,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1574,9 +1522,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1625,9 +1573,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -1654,16 +1602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1691,15 +1629,15 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1718,9 +1656,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1756,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1804,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1816,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1827,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1903,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -1918,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -1938,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2003,12 +1941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2071,15 +2003,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2089,15 +2021,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2152,9 +2084,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2223,7 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2271,12 +2203,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2286,15 +2217,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2346,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -2361,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2420,20 +2351,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2490,21 +2421,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -2629,27 +2554,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2660,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2670,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2680,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2693,33 +2609,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -2736,22 +2630,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2769,18 +2651,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2935,91 +2817,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -3029,9 +2829,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3052,18 +2852,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3072,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3093,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3132,6 +2932,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,12 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -36,6 +30,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -88,6 +91,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +139,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base64"
@@ -112,16 +176,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.4",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -177,14 +303,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -227,10 +391,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -239,7 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -260,33 +452,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
 dependencies = [
- "percent-encoding",
- "time",
- "version_check",
+ "typewit",
 ]
 
 [[package]]
-name = "cookie_store"
-version = "0.22.1"
+name = "constant_time_eq"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -315,12 +505,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -355,6 +581,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +617,12 @@ checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
 
 [[package]]
 name = "darling"
@@ -408,16 +669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +706,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,13 +759,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-stack"
@@ -529,7 +798,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -582,16 +851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,21 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +870,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -713,6 +963,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -835,14 +1094,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -851,7 +1122,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -863,9 +1134,45 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -894,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -920,39 +1227,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hf-hub"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+checksum = "e7ccb6bcc85dec15413ef5949879f9a5497ca4568ed702547eb83fac23376e5c"
 dependencies = [
- "dirs",
+ "base64 0.22.1",
+ "bon",
+ "bytes",
  "futures",
- "http",
- "indicatif",
- "libc",
- "log",
- "native-tls",
- "num_cpus",
- "rand",
+ "getrandom 0.2.17",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "ureq",
- "windows-sys 0.61.2",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6e94f549dbe76ced2c56ada52958e63f9056afabb21f74aae1b5777c8cd5d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "more-asserts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
 ]
 
 [[package]]
@@ -995,6 +1330,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,22 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1403,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1231,15 +1589,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1253,7 +1693,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -1273,6 +1713,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,16 +1737,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1332,6 +1793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,20 +1814,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -1366,7 +1836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1393,21 +1863,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
+name = "more-asserts"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "nom"
@@ -1417,6 +1876,24 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1446,13 +1923,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "hermit-abi",
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
  "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1466,6 +1961,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -1490,47 +1991,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1539,25 +2003,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
+name = "pathdiff"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1602,6 +2092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,7 +2117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libm",
  "num-complex",
  "paste",
@@ -1632,6 +2132,63 @@ name = "pulp-wasm-simd-flag"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "quote"
@@ -1661,7 +2218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1671,7 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1681,6 +2249,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1730,6 +2313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,9 +2363,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1786,21 +2378,23 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1813,17 +2407,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1845,13 +2468,24 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "log",
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1860,8 +2494,36 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1869,6 +2531,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1885,6 +2548,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "safetensors"
@@ -1941,6 +2610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,16 +2688,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.10"
+name = "simd_cesu8"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2033,17 +2781,6 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2071,6 +2808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2828,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -2125,6 +2878,20 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -2202,6 +2969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,14 +3018,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokenizers"
-version = "0.22.2"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -2261,7 +3052,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2302,12 +3093,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-retry"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
- "native-tls",
+ "pin-project-lite",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -2332,6 +3124,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2386,7 +3202,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2396,6 +3237,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2403,6 +3287,30 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2450,42 +3358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "cookie_store",
- "der",
- "flate2",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "ureq-proto",
- "utf8-zero",
- "webpki-root-certs",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,10 +3370,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8-zero"
-version = "0.8.1"
+name = "urlencoding"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2516,10 +3388,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "uuid"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2553,6 +3436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,12 +3454,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -2618,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2659,12 +3560,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.8"
+name = "whoami"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
- "rustls-pki-types",
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -2699,10 +3604,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2768,6 +3750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,6 +3817,151 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xet-client"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45fc10a88b05d4824d7fc0f97d04c13eaea98da5e8032194b8a0cbdab942090"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.2",
+ "redb",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb39bc5e0478e8f03e15f08b0a396f197fcfa2ef5027da666fd100c806bf0ea3"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "countio",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.3",
+ "heapify",
+ "itertools",
+ "lazy_static",
+ "lz4_flex",
+ "more-asserts",
+ "rand 0.10.2",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e428a3b9667c1d0d335a4c77407c04d3a3e6c4f228aee364a1b56ed94cf861ca"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "gearhash",
+ "http",
+ "itertools",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e1f8cfa256029d1bba7860ca12bfd145f17aa7aede5d968e9c304047656be1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor",
+ "dirs",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "web-time",
+ "whoami",
+ "winapi",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mamba-rs"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.97"
 authors = ["silvermpx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ keywords = ["mamba", "ssm", "deep-learning", "cuda", "state-space-model"]
 categories = ["science", "mathematics"]
 readme = "README.md"
 
+# docs.rs builds have no CUDA toolkit -- render the CPU-side API surface
+# (hf loaders, BLAS-backed GEMM, the CLI types). The cuda feature's docs
+# render locally; doc(cfg) badge plumbing is a planned follow-up.
+[package.metadata.docs.rs]
+features = ["hf", "gemm-blas", "cli"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bin]]
 name = "mamba-generate"
 path = "src/bin/generate.rs"
@@ -64,18 +71,19 @@ optional = true
 features = ["derive"]
 
 [dependencies.tokenizers]
-version = "0.22"
+version = "0.23"
 optional = true
 
 [dependencies.hf-hub]
-version = "0.5"
+version = "1"
 optional = true
+features = ["blocking"]
 
 
 [dev-dependencies]
 tempfile = "3"
 
 [dependencies.cudarc]
-version = "0.19.7"
+version = "0.19.8"
 optional = true
 features = ["driver", "cublas", "nvrtc", "cuda-version-from-build-system"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mamba-rs"
 version = "0.4.2"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.97"
 authors = ["silvermpx"]
 description = "Mamba SSM and Mamba-3 SISO in Rust with optional CUDA GPU acceleration. Inference and training (BPTT through SSM state, AdamW), CPU + GPU paths, custom CUDA kernels, CUDA Graph capture, f32 / bf16 / f16. Opt-in deterministic training (bit-identical runs, batch-invariant inference) with a tensor-core tier that beats cuBLAS on LLM-sized models."
 homepage = "https://github.com/silvermpx/mamba-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cli = ["hf", "dep:clap", "dep:tokenizers", "dep:hf-hub"]
 [dependencies]
 pulp = "0.22"
 rayon = "1.10"
-safetensors = "0.7"
+safetensors = "0.8"
 
 [dependencies.gemm]
 version = "0.19"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,33 @@ Pure Rust + CUDA. Kernels compile at runtime via NVRTC.
   deterministic (own numeric contract), at-or-near cuBLAS parity even on
   d128/d256 models and **faster than cuBLAS** from d_model ≥ 768
   (0.70× of PEDANTIC per step at d1536 bf16).
+- **Bring-your-own-loss training split** — `trainer.forward()` returns the
+  full `batch * seq_len * d_model` post-norm_f temporal output on the host;
+  compute ANY loss gradient in plain Rust and feed it to
+  `trainer.backward_step()` (global-norm clipping, exact gradient
+  accumulation, LR schedules via `set_lr`, reference-faithful AdamW
+  no-decay groups). Bit-identical to the fused `step()` — both compose the
+  same eager phase bodies. Same API on `Mamba3Trainer`.
+- **Full-sequence CPU prefill** — `forward_prefill` runs a whole prompt/page
+  through the training forward's batched-SGEMM pipeline (no activation
+  tape) instead of T per-step dispatches, then hands the recurrent state to
+  the step path (prefill-then-decode). Serial mode is the deterministic
+  reference; `PrefillMode::Parallel` parallelizes every phase and stays
+  bit-equal. Both architectures.
 - **HuggingFace loader** — safetensors, synthetic + real Mamba SSM
   checkpoints (130m / 370m / 1.4b / 2.8b validated).
-- **Standalone** — no framework dependency.
+- **Standalone** — no framework dependency. MSRV 1.97.
+
+## Cargo features
+
+| feature | what it enables | when |
+|---|---|---|
+| *(default)* | pure-Rust scalar GEMM | correctness work only — 5-20x slower |
+| `gemm-blas` | [`gemm`] crate BLAS-class CPU GEMM (+ rayon) | ANY serious CPU use |
+| `accelerate` | Apple Accelerate GEMM (macOS) | macOS deployments |
+| `cuda` | GPU inference + training (NVRTC-compiled kernels) | needs the CUDA toolkit |
+| `hf` | safetensors/HF checkpoint loaders | LM checkpoints |
+| `cli` | `mamba-generate` binary (tokenizers + hf-hub) | text generation CLI |
 
 ## Use cases and API choice
 
@@ -64,6 +88,18 @@ single-digit tokens/sec regardless of implementation.
 The CPU `MambaLM` path compiles and runs end-to-end, but exists for
 CPU↔GPU parity testing (`tests/hf_batch_parity.rs`), not for production
 LLM serving.
+
+### Sequence classification / embeddings / custom heads
+
+Whole-sequence reads with a caller-defined loss (document classifiers,
+distillation, contrastive embedding). GPU training rides the
+forward/backward split; CPU serving rides the prefill.
+
+- **Training** — `MambaTrainer::forward` + host-side loss +
+  `MambaTrainer::backward_step` (see `examples/custom_loss.rs`)
+- **CPU serving** — `MambaBackbone::forward_prefill` /
+  `forward_mamba3_backbone_prefill` (see `examples/cpu_prefill.rs`);
+  batches of sequences via `prefill_batch` / `prefill3_batch`
 
 ### Sharing weights across paths
 
@@ -109,7 +145,7 @@ mamba3_step(&mut output, &input, &mut scratch, &weights, &mut state.layers, &cfg
 
 ```toml
 [dependencies]
-mamba-rs = { version = "0.4", features = ["cuda"] }
+mamba-rs = { version = "0.5", features = ["cuda"] }
 ```
 
 `GpuMambaBackbone::new_with_dtype` and the symmetric Mamba-3 constructor take
@@ -178,6 +214,51 @@ let master = trainer.snapshot_master()?; // CPU-side MambaWeights for checkpoint
 `Mamba3Trainer` mirrors the same API. f16 training activates the dynamic
 loss scaler automatically; `metrics.loss_scale` / `metrics.overflow_skipped`
 report its state each step.
+
+### Custom losses: the forward/backward split
+
+The fused `step()` needs the loss gradient up front; the split lets you
+compute it from the actual forward output:
+
+```rust
+use mamba_rs::mamba_ssm::gpu::trainer::BackwardOpts;
+
+let mut temporal = vec![0.0f32; batch * seq_len * cfg.d_model];
+trainer.forward(&input, &mut temporal)?;          // full temporal readback (f32)
+let d_temporal = my_loss_grad(&temporal);          // any host-side loss
+let m = trainer.backward_step(
+    &d_temporal,
+    BackwardOpts::default().with_clip_max_norm(1.0),
+)?;                                                // backward + clip + AdamW
+// gradient accumulation: .with_accumulate_only(true) on the non-applying
+// micro-batches (the fused step() refuses while a window is open).
+```
+
+Always eager (a caller-side loss cannot live inside a captured graph), and
+bit-identical to the fused `step()` — both compose the same phase bodies.
+See `examples/custom_loss.rs` for a complete training loop.
+
+## Quick start (CPU prefill)
+
+```rust
+use mamba_rs::inference::PrefillMode;
+use mamba_rs::module::MambaBackbone;
+
+let backbone = MambaBackbone::init(cfg, input_dim, 42);
+let mut state = backbone.alloc_state();
+let mut scratch = backbone.alloc_prefill_scratch(seq_len);
+let mut out = vec![0.0f32; seq_len * backbone.config().d_model];
+
+// One batched-SGEMM pass over the whole prompt instead of T step dispatches.
+backbone.forward_prefill(&prompt, &mut out, &mut state, &mut scratch,
+                         seq_len, PrefillMode::Parallel);
+// `out` holds the post-norm_f output at EVERY position (pooling-ready);
+// `state` is positioned after the prompt — forward_step continues from it.
+```
+
+Enable `gemm-blas` (or `accelerate` on macOS) — the default scalar GEMM is
+a correctness fallback, not a serving configuration. Mamba-3 has the same
+surface (`forward_mamba3_backbone_prefill` + `Mamba3PrefillScratch`).
 
 ## Serialization
 

--- a/docs/mamba1-architecture.md
+++ b/docs/mamba1-architecture.md
@@ -60,12 +60,19 @@ mamba_block_step(hidden, layer_weights, state, scratch, cfg);
 
 // Level 3: Full backbone — input_proj + N blocks + norm_f
 mamba_step(input, output, weights, states, scratch, cfg, input_dim);
+
+// Full-sequence variant of level 3 (0.5.0): one batched-SGEMM pass over
+// T positions instead of T step dispatches; state carries in AND out so
+// mamba_step continues from it (prefill-then-decode).
+forward_mamba_backbone_prefill(out, input, weights, state, scratch, dims);
 ```
 
 ## Recurrent State
 
 2 persistent states per layer:
-- `conv_state`: `[d_inner, d_conv]` — conv1d shift register
+- `conv_state`: `[(d_conv - 1) * d_inner]` — conv1d history (the training
+  pipeline uses a `d_conv`-wide shift register; the prefill widens on
+  entry and writes the last `d_conv - 1` entries back on exit)
 - `ssm_state`: `[d_inner, d_state]` — SSM hidden state
 
 ## Weight Layout

--- a/docs/mamba3-architecture.md
+++ b/docs/mamba3-architecture.md
@@ -91,6 +91,10 @@ Applied as 2D rotation pairs to B and C before SSM recurrence.
 - `v_state`: `[nheads, headdim]` — previous x
 - `angle_state`: `[nheads, num_rope_angles]` — cumulative RoPE angles
 
+All four carry through `forward_mamba3_backbone_prefill` (0.5.0 —
+full-sequence batched-SGEMM CPU forward, no activation tape) exactly as
+through `mamba3_step`, so prefill-then-decode is seamless.
+
 ## Weight Layout
 
 | Weight | Shape | Bias |

--- a/docs/mamba3-architecture.md
+++ b/docs/mamba3-architecture.md
@@ -20,7 +20,7 @@ Reference: Lahoti et al., *Mamba-3: Improved Sequence Modeling using State Space
     |   /  |  |  |  |  |  |  \     |
     |  z   x  B  C  dt  A  λ  θ    |
     |      |  |  |  |   |  |  |    |
-    |      | BCNorm    softplus     |
+    |      | BCNorm    sp / -ht     |
     |      |  |  |  |   |  sig     |
     |      | bias  bias clamp      |
     |      |  |  |  |              |
@@ -43,6 +43,11 @@ Reference: Lahoti et al., *Mamba-3: Improved Sequence Modeling using State Space
         |
     output [B, T, d_model]
 ```
+
+Activations in the split: `sp` = softplus(dd_dt + dt_bias) on dt; `-ht` =
+`-heavy_tail(dd_A)` clamped at `-a_floor` on A (state-spaces/mamba
+`heavy_tail_activation`: `1 + x` for `x >= 0`, `1 / (1 - x)` for `x < 0`);
+`sig` = sigmoid on the trapezoid gate λ.
 
 ## Key Differences from Mamba SSM
 

--- a/examples/cpu_prefill.rs
+++ b/examples/cpu_prefill.rs
@@ -1,0 +1,94 @@
+//! Full-sequence CPU prefill, then per-step decode (prefill-then-decode).
+//!
+//! ```bash
+//! cargo run --release --example cpu_prefill --features gemm-blas
+//! ```
+//!
+//! The per-step inference path costs one matvec pipeline per token — a
+//! whole prompt/page of T tokens pays T dispatches. `forward_prefill` runs
+//! the training forward's batched-SGEMM pipeline instead (no activation
+//! tape), writes the post-norm_f output at EVERY position, and carries the
+//! recurrent state so `forward_step` continues seamlessly.
+//!
+//! Featureless builds work but use the pure-Rust scalar GEMM (5-20x
+//! slower) — real deployments enable `gemm-blas` (or `accelerate` on
+//! macOS). `PrefillMode::Parallel` additionally parallelizes every phase
+//! for single-sequence latency; batches of independent sequences should
+//! prefer `prefill_batch` (one core per sequence).
+
+use std::time::Instant;
+
+use mamba_rs::MambaConfig;
+use mamba_rs::inference::PrefillMode;
+use mamba_rs::module::MambaBackbone;
+
+fn main() {
+    let cfg = MambaConfig {
+        d_model: 256,
+        n_layers: 8,
+        ..MambaConfig::default()
+    };
+    let input_dim = 128;
+    let seq_len = 512;
+    let backbone = MambaBackbone::init(cfg, input_dim, 42);
+    let dm = backbone.config().d_model;
+
+    // A synthetic "prompt": T feature vectors.
+    let prompt: Vec<f32> = (0..seq_len * input_dim)
+        .map(|i| ((i % 251) as f32 / 251.0 - 0.5) * 0.1)
+        .collect();
+
+    // Prefill the whole prompt in one call.
+    let mut state = backbone.alloc_state();
+    let mut prefill_scratch = backbone.alloc_prefill_scratch(seq_len);
+    let mut prefill_out = vec![0.0f32; seq_len * dm];
+    let start = Instant::now();
+    backbone.forward_prefill(
+        &prompt,
+        &mut prefill_out,
+        &mut state,
+        &mut prefill_scratch,
+        seq_len,
+        PrefillMode::Parallel,
+    );
+    let prefill_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    // The same tokens through the per-step loop, for comparison.
+    let mut step_state = backbone.alloc_state();
+    let mut step_scratch = backbone.alloc_scratch();
+    let mut step_out = vec![0.0f32; seq_len * dm];
+    let start = Instant::now();
+    backbone.forward_sequence(
+        &prompt,
+        &mut step_out,
+        &mut step_state,
+        &mut step_scratch,
+        seq_len,
+    );
+    let steps_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    println!("prefill (T={seq_len}):  {prefill_ms:8.2} ms");
+    println!(
+        "step loop (T={seq_len}): {steps_ms:8.2} ms  ({:.1}x)",
+        steps_ms / prefill_ms
+    );
+
+    // Decode continues FROM the prefilled state — feed the next token.
+    let next_input = vec![0.05f32; input_dim];
+    let mut next_out = vec![0.0f32; dm];
+    backbone.forward_step(&next_input, &mut next_out, &mut state, &mut step_scratch);
+    println!("decode after prefill: out[0..4] = {:?}", &next_out[..4]);
+
+    // Pooling consumers read every position of `prefill_out` (norm_f is
+    // applied at each one), e.g. a mean-pool for classification:
+    let mut pooled = vec![0.0f32; dm];
+    for row in prefill_out.chunks(dm) {
+        for (p, &v) in pooled.iter_mut().zip(row) {
+            *p += v;
+        }
+    }
+    for p in pooled.iter_mut() {
+        *p /= seq_len as f32;
+    }
+    println!("mean-pooled feature: pooled[0..4] = {:?}", &pooled[..4]);
+}

--- a/examples/custom_loss.rs
+++ b/examples/custom_loss.rs
@@ -1,0 +1,141 @@
+//! Bring-your-own-loss GPU training with the forward/backward split.
+//!
+//! ```bash
+//! cargo run --release --example custom_loss --features cuda
+//! ```
+//!
+//! The fused `MambaTrainer::step(input, d_temporal)` requires the caller to
+//! already HOLD the loss gradient — but computing a loss needs the forward
+//! activations first. The split API resolves that:
+//!
+//!   1. `forward()` — runs the training forward, returns the full
+//!      `batch * seq_len * d_model` post-norm_f temporal output on the host;
+//!   2. the caller computes ANY loss + its gradient w.r.t. that output
+//!      (classification head, distillation KL, contrastive — plain Rust);
+//!   3. `backward_step()` — backprops that gradient through the saved
+//!      activations and runs AdamW (optionally with global-norm clipping,
+//!      or `accumulate_only` for gradient accumulation across micro-batches).
+//!
+//! The demo trains a tiny backbone to push its mean-pooled output toward a
+//! fixed target vector (MSE) — a stand-in for any real head/loss.
+
+#[cfg(not(feature = "cuda"))]
+fn main() {
+    eprintln!("This example requires the `cuda` feature:");
+    eprintln!("  cargo run --release --example custom_loss --features cuda");
+}
+
+#[cfg(feature = "cuda")]
+mod cuda_example {
+    use mamba_rs::MambaConfig;
+    use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+    use mamba_rs::mamba_ssm::gpu::trainer::{BackwardOpts, MambaTrainer, TrainSessionCfg};
+    use mamba_rs::weights::MambaWeights;
+
+    pub fn run() -> Result<(), String> {
+        let cfg = MambaConfig {
+            d_model: 64,
+            n_layers: 2,
+            ..MambaConfig::default()
+        };
+        let input_dim = 32;
+        let (batch, seq_len) = (2usize, 16usize);
+        let dm = cfg.d_model;
+        let n_in = batch * seq_len * input_dim;
+        let n_out = batch * seq_len * dm;
+
+        let weights = MambaWeights::init(&cfg, input_dim, 42);
+        let mut trainer = MambaTrainer::new_full(
+            0,
+            &weights,
+            cfg,
+            TrainSessionCfg {
+                input_dim,
+                batch,
+                seq_len,
+                lr: 3e-3,
+                weight_decay: 1e-2,
+            },
+            WeightDtype::Bf16,
+        )?;
+
+        // Synthetic input and a fixed target for the mean-pooled feature.
+        let input: Vec<f32> = (0..n_in)
+            .map(|i| ((i % 97) as f32 / 97.0 - 0.5) * 0.2)
+            .collect();
+        let target: Vec<f32> = (0..dm)
+            .map(|i| if i % 2 == 0 { 0.5 } else { -0.5 })
+            .collect();
+
+        let mut temporal = vec![0.0f32; n_out];
+        let mut d_temporal = vec![0.0f32; n_out];
+
+        for step in 0..30 {
+            trainer.reset_state()?;
+
+            // 1. Forward: full temporal readback (f32 on every dtype).
+            trainer.forward(&input, &mut temporal)?;
+
+            // 2. Host-side loss: L = mean_b || meanpool_t(y) - target ||^2.
+            //    dL/dy[b,t,d] = 2 * (pool[b,d] - target[d]) / (T * B).
+            let mut loss = 0.0f64;
+            for b in 0..batch {
+                let sample = &temporal[b * seq_len * dm..(b + 1) * seq_len * dm];
+                let mut pool = vec![0.0f32; dm];
+                for row in sample.chunks(dm) {
+                    for (p, &v) in pool.iter_mut().zip(row) {
+                        *p += v;
+                    }
+                }
+                for p in pool.iter_mut() {
+                    *p /= seq_len as f32;
+                }
+                for (d, (&p, &tv)) in pool.iter().zip(&target).enumerate() {
+                    let diff = p - tv;
+                    loss += (diff * diff) as f64 / batch as f64;
+                    let g = 2.0 * diff / (seq_len as f32 * batch as f32);
+                    for t in 0..seq_len {
+                        d_temporal[b * seq_len * dm + t * dm + d] = g;
+                    }
+                }
+            }
+
+            // 3. Backward + AdamW, with global-norm clipping at 1.0.
+            let m = trainer
+                .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1.0))?;
+            if step % 5 == 0 {
+                println!(
+                    "step {:2}  loss {:.5}  grad_norm {:.4}",
+                    step,
+                    loss,
+                    m.grad_norm.unwrap_or(f32::NAN)
+                );
+            }
+
+            // A cosine-ish LR decay via set_lr (illegal under a captured
+            // graph; the split path is always eager, so it just works).
+            trainer.set_lr(3e-3 * (1.0 - step as f32 / 40.0))?;
+        }
+
+        // Gradient accumulation: two micro-batches, one optimizer step.
+        // Scale d_temporal by 1/n_micro caller-side for loss averaging.
+        trainer.reset_state()?;
+        trainer.forward(&input, &mut temporal)?;
+        let half: Vec<f32> = d_temporal.iter().map(|g| g * 0.5).collect();
+        trainer.backward_step(&half, BackwardOpts::default().with_accumulate_only(true))?;
+        trainer.reset_state()?;
+        trainer.forward(&input, &mut temporal)?;
+        let m = trainer.backward_step(&half, BackwardOpts::default())?;
+        println!("accumulated step -> adam step {}", m.step);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn main() {
+    if let Err(e) = cuda_example::run() {
+        eprintln!("custom_loss example failed: {e}");
+        std::process::exit(1);
+    }
+}

--- a/kernels/gemm_batch_invariant.cu
+++ b/kernels/gemm_batch_invariant.cu
@@ -395,46 +395,51 @@ NAME(                                                                           
     extern __shared__ unsigned char smem_a_raw[];                               \
     T_IO* smem_a = reinterpret_cast<T_IO*>(smem_a_raw);                         \
                                                                                 \
-    /* Cooperative global→smem load of a_row[0..K).                         */  \
-    /* Vectorized 128-bit async loads via cp.async.cg (sm_80+).             */  \
-    /* uint4 = 16 bytes = 8 bf16/f16 or 4 f32. Batch-invariance preserved:  */  \
-    /* element values are identical to scalar path; smem write order        */  \
-    /* does not affect later per-col K reduction.                           */  \
-    {                                                                           \
-        const int VEC = 16 / (int)sizeof(T_IO);                                 \
-        const int k_vec = k / VEC;                                              \
-        const uint4* a_vec =                                                    \
-            reinterpret_cast<const uint4*>(a_row);                              \
-        uint4* smem_a_vec = reinterpret_cast<uint4*>(smem_a);                   \
-        _Pragma("unroll 1")                                                     \
-        for (int i = threadIdx.x; i < k_vec; i += THREADS_PER_BLOCK) {          \
-            __pipeline_memcpy_async(                                            \
-                &smem_a_vec[i], &a_vec[i], sizeof(uint4));                      \
-        }                                                                       \
-        __pipeline_commit();                                                    \
-        /* Scalar tail for k % VEC != 0 (still sync). */                        \
-        const int k_tail_start = k_vec * VEC;                                   \
-        for (int i = k_tail_start + threadIdx.x; i < k;                         \
-             i += THREADS_PER_BLOCK) {                                          \
-            smem_a[i] = a_row[i];                                               \
-        }                                                                       \
-        __pipeline_wait_prior(0);                                               \
-    }                                                                           \
-    __syncthreads();                                                            \
-                                                                                \
-    /* K-partition: each warp takes a contiguous range of K. */                 \
-    const int k_per_warp = (k + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;         \
-    const int k_start = warp_id * k_per_warp;                                   \
-    const int k_stop = min(k, k_start + k_per_warp);                            \
+    /* Cooperative global->smem load of a_row[0..K). Vectorized 128-bit */ \
+    /* cp.async.cg (sm_80+) when EVERY A row is 16-byte aligned (row     */ \
+    /* offset = row*k*sizeof(T_IO)); an arbitrary K (e.g. a vision patch */ \
+    /* dim) can misalign rows - those take the all-scalar fill. smem     */ \
+    /* contents are identical either way, so the per-col K reduction     */ \
+    /* (and its bits) never depends on the path taken.                   */ \
+    {                                                                       \
+        const int VEC = 16 / (int)sizeof(T_IO);                             \
+        if ((k * (int)sizeof(T_IO)) % 16 == 0) {                            \
+            const int k_vec = k / VEC;                                      \
+            const uint4* a_vec =                                            \
+                reinterpret_cast<const uint4*>(a_row);                      \
+            uint4* smem_a_vec = reinterpret_cast<uint4*>(smem_a);           \
+            _Pragma("unroll 1")                                             \
+            for (int i = threadIdx.x; i < k_vec; i += THREADS_PER_BLOCK) {  \
+                __pipeline_memcpy_async(                                    \
+                    &smem_a_vec[i], &a_vec[i], sizeof(uint4));              \
+            }                                                               \
+            __pipeline_commit();                                            \
+            __pipeline_wait_prior(0);                                       \
+        } else {                                                            \
+            for (int i = threadIdx.x; i < k; i += THREADS_PER_BLOCK) {      \
+                smem_a[i] = a_row[i];                                       \
+            }                                                               \
+        }                                                                   \
+    }                                                                       \
+    __syncthreads();                                                        \
+                                                                            \
+    /* K-partition: each warp takes a contiguous range of K, rounded up  */ \
+    /* to an EVEN span so every warp's k_start stays pair-aligned for    */ \
+    /* the packed smem reads below. Even spans (every historic HF        */ \
+    /* d_model) are unchanged - bit-stability preserved; odd spans       */ \
+    /* previously FAULTED (misaligned LDS.U32 at an odd element offset). */ \
+    int k_per_warp = (k + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;           \
+    k_per_warp += (k_per_warp & 1);                                         \
+    const int k_start = warp_id * k_per_warp;                               \
+    const int k_stop = min(k, k_start + k_per_warp);                        \
                                                                                 \
     /* OPT C: packed smem_a reads via pair_to_f2 helper. For bf16/f16 this  */ \
     /* halves LDS instruction count (1 LDS.U32 → 2 elements vs 2× LDS.U16).*/  \
     /* Address must be 4-byte aligned: kk steps by 8, smem_a starts at 0,  */  \
     /* so kk is always even and pair-aligned.                              */  \
-    /* OPT E: tell ptxas K is a multiple of 8 (HF Mamba: d_model ∈ {768,   */  \
-    /* 1024, 2048, 2560} all div by 8). Lets compiler drop the tail loop   */  \
-    /* and keep `kk < k_main` purely as a single-strand bound.             */  \
-    __builtin_assume((k & 7) == 0);                                             \
+    /* (An earlier __builtin_assume((k & 7) == 0) was removed: it was UB */ \
+    /* for arbitrary K - vision patch dims - and the scalar tail below   */ \
+    /* already handles k % 8 != 0 correctly at negligible cost.)         */ \
     float acc = 0.0f;                                                           \
     if (in_range && k_start < k_stop) {                                         \
         int kk = k_start;                                                       \

--- a/kernels/grad_clip.cu
+++ b/kernels/grad_clip.cu
@@ -1,0 +1,47 @@
+// Global-norm gradient clipping support.
+//
+// Deterministic sum-of-squares partial reduction over the flat grad arena:
+// FIXED grid (GCLIP_BLOCKS x GCLIP_THREADS) with a fixed-stride grid loop,
+// per-thread f64 accumulation, fixed shared-memory tree reduce, one f64
+// partial per block. The host performs the final ordered sum of the
+// GCLIP_BLOCKS partials — no atomics anywhere, so the norm is bit-stable
+// across runs (an atomicAdd norm would be the crate's first determinism
+// regression). The actual clip scaling reuses the existing scale_grads_f32
+// elementwise kernel.
+//
+// Section-local geometry constants, #undef'd at end of section (the 0.4.0
+// ambient-defines lesson: kernel sections must own their geometry).
+
+#define GCLIP_THREADS 256
+#define GCLIP_BLOCKS 512
+
+// partials: [GCLIP_BLOCKS] f64, one per block.
+// Launch geometry MUST be exactly (GCLIP_BLOCKS, GCLIP_THREADS) — the
+// fixed-stride loop and the partial count depend on it.
+extern "C" __global__ void grad_sumsq_partial_f32(
+    double* __restrict__ partials,
+    const float* __restrict__ g,
+    int n
+) {
+    __shared__ double smem[GCLIP_THREADS];
+    double acc = 0.0;
+    const int stride = GCLIP_BLOCKS * GCLIP_THREADS;
+    for (int i = blockIdx.x * GCLIP_THREADS + threadIdx.x; i < n; i += stride) {
+        double v = (double)g[i];
+        acc += v * v;
+    }
+    smem[threadIdx.x] = acc;
+    __syncthreads();
+    for (int s = GCLIP_THREADS / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) {
+            smem[threadIdx.x] += smem[threadIdx.x + s];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        partials[blockIdx.x] = smem[0];
+    }
+}
+
+#undef GCLIP_THREADS
+#undef GCLIP_BLOCKS

--- a/kernels/mamba3_ops.cu
+++ b/kernels/mamba3_ops.cu
@@ -36,7 +36,7 @@
 //   - z, x:        pass-through
 //   - B_raw, C_raw: pass-through
 //   - dt:          softplus(dd_dt + dt_bias)
-//   - a_val:       -softplus(dd_A), clamped to max = -a_floor
+//   - a_val:       -heavy_tail(dd_A), clamped to max = -a_floor
 //   - trap:        sigmoid(trap_raw)
 //   - angles:      pass-through
 //
@@ -46,7 +46,7 @@
 //
 // Input:  proj[N * in_proj_dim]
 // Outputs: z[N*di], x[N*di], B_raw[N*ng*ds], C_raw[N*ng*ds],
-//          dt[N*nh] (post-softplus), a_val[N*nh] (neg-softplus clamped),
+//          dt[N*nh] (post-softplus), a_val[N*nh] (neg-heavy-tail clamped),
 //          trap[N*nh] (post-sigmoid), angles[N*n_angles] (pass-through),
 //          dd_dt_raw[N*nh] (saved for backward), dd_a_raw[N*nh] (saved for backward),
 //          trap_raw[N*nh] (saved for backward)
@@ -75,7 +75,7 @@ extern "C" __global__ void m3_split(
     float* __restrict__ B_raw,      // [N * ng * ds]
     float* __restrict__ C_raw,      // [N * ng * ds]
     float* __restrict__ dt,         // [N * nh] -- post-softplus
-    float* __restrict__ a_val,      // [N * nh] -- -softplus(dd_A), clamped
+    float* __restrict__ a_val,      // [N * nh] -- -heavy_tail(dd_A), clamped
     float* __restrict__ trap,       // [N * nh] -- post-sigmoid
     float* __restrict__ angles,     // [N * n_angles]
     float* __restrict__ dd_dt_raw,  // [N * nh] -- saved for backward
@@ -744,7 +744,7 @@ extern "C" __global__ void m3_compute_abg(
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= N) return;
     float dt_v = dt[idx];
-    float a_v = a_val[idx];    // already negative (-softplus clamped)
+    float a_v = a_val[idx];    // already negative (-heavy_tail clamped)
     float t_v = trap[idx];     // already sigmoided
     float alpha_v = FAST_EXP(a_v * dt_v);
     alpha[idx] = alpha_v;
@@ -753,12 +753,12 @@ extern "C" __global__ void m3_compute_abg(
 }
 
 // ============================================================================
-// 9. m3_abg_bwd -- Backward through alpha/beta/gamma + softplus/sigmoid
+// 9. m3_abg_bwd -- Backward through alpha/beta/gamma + softplus/heavy-tail/sigmoid
 // ============================================================================
 //
 // Forward (m3_compute_abg + m3_split activations):
 //   dt_val = softplus(dd_dt_raw + dt_bias)
-//   a_val  = clamp(-softplus(dd_a_raw), max = -a_floor)
+//   a_val  = clamp(-heavy_tail(dd_a_raw), max = -a_floor)
 //   trap_sig = sigmoid(trap_raw)
 //   alpha  = exp(a_val * dt_val)
 //   beta   = alpha * dt_val * (1 - trap_sig)
@@ -784,10 +784,10 @@ extern "C" __global__ void m3_abg_bwd(
     const float* __restrict__ d_gamma, // [N]
     const float* __restrict__ d_dt_angle, // [N] -- angle contribution to d_dt (from angle_dt_bwd)
     const float* __restrict__ dt,      // [N] -- post-softplus dt
-    const float* __restrict__ a_val,   // [N] -- clamped -softplus(dd_a)
+    const float* __restrict__ a_val,   // [N] -- clamped -heavy_tail(dd_a)
     const float* __restrict__ alpha,   // [N] -- exp(a_val * dt)
     const float* __restrict__ dd_dt_raw, // [N] -- saved raw (pre-softplus)
-    const float* __restrict__ dd_a_raw,  // [N] -- saved raw (pre-softplus)
+    const float* __restrict__ dd_a_raw,  // [N] -- saved raw (pre-heavy-tail)
     const float* __restrict__ trap_raw,  // [N] -- saved raw (pre-sigmoid)
     const float* __restrict__ dt_bias, // [nh]
     float a_floor,

--- a/kernels/mamba_ssm.cu
+++ b/kernels/mamba_ssm.cu
@@ -228,13 +228,11 @@ DEFINE_SSM_STEP_FWD_GATHER_GATE(f16,  __half,        from_f_f16)
 
 // SSM burn-in forward (T>1): iterate T steps for each (batch, d_inner) thread.
 // Saves h_saved[B*(T+1)*d_inner*d_state] for backward BPTT and
-// da_exp[B*T*d_inner*d_state] for backward discretization.
 // h and a_neg cached in registers (Opt A). Uses exp2f (Opt B).
 extern "C" __global__ void ssm_burnin_forward(
     float* h,             // [batch * d_inner * d_state] hidden state (mutated through T steps)
     float* y_out,         // [batch * T * d_inner] output
     float* h_saved,       // [batch * (T+1) * d_inner * d_state] h BEFORE each step
-    float* da_exp_out,    // [batch * T * d_inner * d_state] discretization exp
     const float* delta,   // [batch * T * d_inner]
     const float* u,       // [batch * T * d_inner]
     const float* B,       // [batch * T * d_state]
@@ -279,10 +277,8 @@ extern "C" __global__ void ssm_burnin_forward(
             // Opt B: exp2f instead of expf
             float da = exp2f(delta_d * a_local[n] * LOG2E);
 
-            // da_exp_out write removed: backward kernel recomputes da from
-            // delta and a_neg (cheaper than global memory round-trip for
-            // typical d_state=16). Saves bandwidth; buffer kept in interface
-            // for ABI stability.
+            // No da saved: backward recomputes da from delta and a_neg
+            // (cheaper than a global-memory round-trip at d_state=16).
 
             h_local[n] = da * h_local[n] + delta_u_d * B[bt_ds + n];
             y_d += h_local[n] * C[bt_ds + n];
@@ -303,7 +299,7 @@ extern "C" __global__ void ssm_burnin_forward(
 }
 
 // SSM burn-in forward NOSAVE variant (target network — no backward needed).
-// Identical recurrence to ssm_burnin_forward but skips h_saved and da_exp writes.
+// Identical recurrence to ssm_burnin_forward but skips the h_saved writes.
 // Saves ~50% memory bandwidth per layer for target path.
 extern "C" __global__ void ssm_burnin_forward_nosave(
     float* h,             // [batch * d_inner * d_state] hidden state (mutated through T steps)
@@ -407,7 +403,7 @@ DEFINE_SSM_BURNIN_NOSAVE(f16,  __half,        from_f_f16)
 // h_saved and y_out in activation dtype; h_state + a_neg + D in f32.
 #define DEFINE_SSM_BURNIN(SUFFIX, TY, FROM_F)                               \
 extern "C" __global__ void ssm_burnin_forward_##SUFFIX(                     \
-    float* h, TY* y_out, float* h_saved, float* da_exp_out,                 \
+    float* h, TY* y_out, float* h_saved,                                    \
     const TY* delta, const TY* u,                                           \
     const TY* B, const TY* C,                                               \
     const float* a_neg, const float* D,                                     \

--- a/kernels/mamba_ssm_parallel.cu
+++ b/kernels/mamba_ssm_parallel.cu
@@ -29,7 +29,7 @@
 // Typed-I/O prelude (to_f / from_f_* upcast/downcast helpers).
 // Step 8b: bf16/f16 mixed-precision parallel scan forward. Following
 // state-spaces/mamba's `scan_t = float2` invariant (all scan state in
-// f32) and our Step 5 BPTT precision discipline (h, h_saved, da_exp_out,
+// f32) and our Step 5 BPTT precision discipline (h, h_saved,
 // a_neg, D, smem_* remain f32). Only the activation I/O tensors
 // (delta, u, B, C, y_out) are typed.
 #include "_typed_prelude.cuh"
@@ -266,7 +266,6 @@ extern "C" __global__ __launch_bounds__(128, 3) void ssm_parallel_scan_fwd(
     float* __restrict__ h,             // [batch * d_inner * d_state] SSM state (mutated)
     float* __restrict__ y_out,         // [batch * T * d_inner] output
     float* __restrict__ h_saved,       // [batch * (T+1) * d_inner * d_state] saved for backward
-    float* __restrict__ da_exp_out,    // [batch * T * d_inner * d_state] saved exp(delta*A)
     const float* __restrict__ delta,   // [batch * T * d_inner]
     const float* __restrict__ u,       // [batch * T * d_inner]
     const float* __restrict__ B,       // [batch * T * d_state]
@@ -398,9 +397,8 @@ extern "C" __global__ __launch_bounds__(128, 3) void ssm_parallel_scan_fwd(
                     float b_t = smem_stage[threadIdx.x * NITEMS + i];
                     thread_a[i] = da;
                     thread_b[i] = delta_u_vals[i] * b_t;
-                    // da_exp_out write removed: backward recomputes da from
-                    // delta and a_neg. Saves bandwidth; buffer kept in
-                    // interface for ABI stability.
+                    // No da saved: backward recomputes da from delta
+                    // and a_neg (bandwidth win).
                 } else {
                     thread_a[i] = 1.0f;  // identity
                     thread_b[i] = 0.0f;
@@ -537,7 +535,7 @@ extern "C" __global__ __launch_bounds__(128, 3) void ssm_parallel_scan_fwd(
 // Forward without saves (target network -- no backward needed).
 //
 // Same interface as ssm_burnin_forward_nosave.
-// Same parallel scan algorithm, skips h_saved and da_exp writes.
+// Same parallel scan algorithm, skips the h_saved writes.
 // ============================================================================
 extern "C" __global__ __launch_bounds__(128, 3) void ssm_parallel_scan_fwd_nosave(
     float* __restrict__ h,             // [batch * d_inner * d_state] SSM state (mutated)
@@ -768,7 +766,7 @@ extern "C" __global__ __launch_bounds__(128, 3) void ssm_parallel_scan_fwd_nosav
 // Follow `state-spaces/mamba`'s `scan_t = float2` discipline: all scan
 // state + running prefix + block scan + registers stay f32. Only the
 // activation I/O tensors (delta, u, B, C, y_out) become typed. BPTT
-// state (`h`, `h_saved`, `da_exp_out`), model parameters (`a_neg`, `D`),
+// state (`h`, `h_saved`), model parameters (`a_neg`, `D`),
 // and ALL `smem_*` (including smem_stage) remain f32.
 // ============================================================================
 
@@ -778,7 +776,6 @@ ssm_parallel_scan_fwd_##SUFFIX(                                               \
     float* __restrict__ h,                                                    \
     T_ACT* __restrict__ y_out,                                                \
     float* __restrict__ h_saved,                                              \
-    float* __restrict__ da_exp_out,                                           \
     const T_ACT* __restrict__ delta,                                          \
     const T_ACT* __restrict__ u,                                              \
     const T_ACT* __restrict__ B,                                              \
@@ -953,7 +950,6 @@ ssm_parallel_scan_fwd_##SUFFIX(                                               \
         float h_0 = h[h_base + n];                                            \
         h[h_base + n] = smem_run_a[n] * h_0 + smem_run_b[n];                  \
     }                                                                         \
-    (void)da_exp_out;                                                         \
 }
 
 DEFINE_SSM_PARALLEL_SCAN_FWD(bf16, __nv_bfloat16, from_f_bf16)

--- a/kernels/sgemm_bi.cu
+++ b/kernels/sgemm_bi.cu
@@ -2596,6 +2596,24 @@ void sgemm_bi_nt_slim(
     } // end persistent CTA loop (slim NT)
 }
 
+// Slim geometry ends here — undef everything so no later-appended section
+// can silently inherit BM=128/BN=64/BK=32 (the 0.4.0 geometry-leak class).
+// Every section below defines its own prefixed macros and undefs them.
+#undef BM
+#undef BN
+#undef BK
+#undef WM
+#undef WN
+#undef WNITER
+#undef TM
+#undef TN
+#undef WMITER
+#undef WSUBM
+#undef WSUBN
+#undef ROW_STRIDE_A
+#undef ROW_STRIDE_B
+#undef NUM_THREADS
+
 // ============================================================================
 // Phase 2.2 — GEMV-N1 NN (forward, N=1): Y[M] = alpha * X[M,K] @ W[K] + beta*Y + bias
 // ============================================================================

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use clap::Parser;
-use hf_hub::api::sync::Api;
+use hf_hub::{HFClientSync, split_id};
 use tokenizers::Tokenizer;
 
 use mamba_rs::module::sample::SampleParams;
@@ -261,18 +261,21 @@ fn print_stats(
 
 fn download_model(model_id: &str, revision: &str) -> PathBuf {
     eprintln!("downloading {model_id} (rev: {revision})...");
-    let api = Api::new().unwrap_or_else(|e| {
-        eprintln!("error: HF Hub API init failed: {e}");
+    let client = HFClientSync::new().unwrap_or_else(|e| {
+        eprintln!("error: HF Hub client init failed: {e}");
         eprintln!("hint: set HF_TOKEN env var for gated models");
         std::process::exit(1);
     });
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        model_id.to_string(),
-        hf_hub::RepoType::Model,
-        revision.to_string(),
-    ));
+    let (owner, name) = split_id(model_id);
+    let repo = client.model(owner, name);
+    let get = |file: &str| {
+        repo.download_file()
+            .filename(file)
+            .revision(revision.to_string())
+            .send()
+    };
 
-    let config = repo.get("config.json").unwrap_or_else(|e| {
+    let config = get("config.json").unwrap_or_else(|e| {
         eprintln!("error: cannot download config.json: {e}");
         std::process::exit(1);
     });
@@ -282,7 +285,7 @@ fn download_model(model_id: &str, revision: &str) -> PathBuf {
     let idx_path = model_dir.join("model.safetensors.index.json");
 
     if !st_path.exists() && !idx_path.exists() {
-        if let Ok(idx) = repo.get("model.safetensors.index.json") {
+        if let Ok(idx) = get("model.safetensors.index.json") {
             let idx_bytes = std::fs::read(&idx).unwrap();
             let index: serde_json::Value = serde_json::from_slice(&idx_bytes).unwrap();
             if let Some(wm) = index.get("weight_map").and_then(|v| v.as_object()) {
@@ -291,14 +294,14 @@ fn download_model(model_id: &str, revision: &str) -> PathBuf {
                 shards.dedup();
                 for shard in shards {
                     eprintln!("  downloading {shard}...");
-                    repo.get(shard).unwrap_or_else(|e| {
+                    get(shard).unwrap_or_else(|e| {
                         eprintln!("error: cannot download {shard}: {e}");
                         std::process::exit(1);
                     });
                 }
             }
         } else {
-            repo.get("model.safetensors").unwrap_or_else(|e| {
+            get("model.safetensors").unwrap_or_else(|e| {
                 eprintln!("error: cannot download model weights: {e}");
                 std::process::exit(1);
             });
@@ -306,7 +309,7 @@ fn download_model(model_id: &str, revision: &str) -> PathBuf {
     }
 
     for name in ["tokenizer.json", "tokenizer_config.json"] {
-        let _ = repo.get(name);
+        let _ = get(name);
     }
 
     model_dir
@@ -321,12 +324,17 @@ fn load_tokenizer(model_dir: &Path, args: &Args) -> Tokenizer {
         })
     } else {
         eprintln!("warning: tokenizer.json not found, trying HF download...");
-        let api = Api::new().unwrap();
-        let repo = api.repo(hf_hub::Repo::model(args.model_id.clone()));
-        let path = repo.get("tokenizer.json").unwrap_or_else(|e| {
-            eprintln!("error: cannot download tokenizer: {e}");
-            std::process::exit(1);
-        });
+        let client = HFClientSync::new().unwrap();
+        let (owner, name) = split_id(&args.model_id);
+        let path = client
+            .model(owner, name)
+            .download_file()
+            .filename("tokenizer.json")
+            .send()
+            .unwrap_or_else(|e| {
+                eprintln!("error: cannot download tokenizer: {e}");
+                std::process::exit(1);
+            });
         Tokenizer::from_file(&path).unwrap_or_else(|e| {
             eprintln!("error: cannot parse tokenizer: {e}");
             std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod weights;
 // most common entrypoints.
 pub mod inference {
     pub use crate::mamba_ssm::cpu::inference::*;
+    pub use crate::mamba_ssm::cpu::prefill::*;
 }
 pub mod train {
     pub use crate::mamba_ssm::cpu::backward;

--- a/src/mamba3_siso/cpu/forward.rs
+++ b/src/mamba3_siso/cpu/forward.rs
@@ -48,7 +48,7 @@ pub(crate) fn simd_sum_sq(x: &[f32]) -> f32 {
 }
 
 #[inline]
-fn simd_rms_scale(out: &mut [f32], x: &[f32], weight: &[f32], inv_rms: f32) {
+pub(crate) fn simd_rms_scale(out: &mut [f32], x: &[f32], weight: &[f32], inv_rms: f32) {
     struct Scale<'a> {
         out: &'a mut [f32],
         x: &'a [f32],

--- a/src/mamba3_siso/cpu/mod.rs
+++ b/src/mamba3_siso/cpu/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! - `dims` — dimension calculator
 //! - `inference` — T=1 recurrent step
+//! - `prefill` — full-sequence batched inference forward (no tape)
 //! - `forward` — training forward (F1-F7)
 //! - `backward` — training BPTT backward (B1-B8)
 //! - `parallel` — rayon batch forward + backward
@@ -15,11 +16,16 @@ pub mod flat;
 pub mod forward;
 pub mod inference;
 pub mod parallel;
+pub mod prefill;
 pub mod scratch;
 pub mod weights;
 
 pub use dims::Mamba3Dims;
 pub use flat::{Mamba3FieldOffsets, Mamba3LayerFlat};
 pub use inference::{Mamba3StepScratch, mamba3_layer_step, mamba3_step};
+pub use prefill::{
+    Mamba3PrefillScratch, forward_mamba3_backbone_prefill, forward_mamba3_backbone_prefill_mode,
+    prefill3_batch,
+};
 pub use scratch::Mamba3Scratch;
 pub use weights::{TrainMamba3LayerWeights, TrainMamba3Weights};

--- a/src/mamba3_siso/cpu/prefill.rs
+++ b/src/mamba3_siso/cpu/prefill.rs
@@ -1,0 +1,606 @@
+//! Full-sequence Mamba-3 CPU inference forward ("prefill") — the M3 twin
+//! of [`crate::mamba_ssm::cpu::prefill`].
+//!
+//! Runs the SAME math as the training layer forward
+//! (`forward_mamba3_layer_batched`) WITHOUT saving the activation tape, on
+//! inference types (`Mamba3Weights` + `Mamba3LayerState`), with the
+//! recurrent SSM/K/V/angle states carried in AND out so `mamba3_step`
+//! continues seamlessly (prefill-then-decode).
+//!
+//! Layout doctrine (the measured M1 lesson): the head-sequential F5 phase
+//! reads ONLY head-major/channel-major buffers — `x_cm [di * T]` plus the
+//! head-scalar columns (`dd_a`/`dd_dt`/`trap` as `[nh * T]`) are pulled out
+//! of the interleaved `[T, in_proj_dim]` projection with cache-blocked
+//! transposes; the shared per-position rows (BCNormed B/C, tanh-pi angle
+//! velocities) stream row-sequentially and stay L2-resident across heads.
+//! In [`PrefillMode::Parallel`] every phase parallelizes (GEMMs, rows,
+//! transpose tiles, and F5 over HEADS — each head owns disjoint state and
+//! `y` column slices) with no cross-task reductions, so Parallel is
+//! bit-equal to Single by construction; both are bit-equal to the training
+//! layer forward (the anchor test pins it).
+
+use rayon::prelude::*;
+
+use crate::mamba_ssm::cpu::prefill::{
+    PrefillMode, for_rows, transpose_cm_to_rm, transpose_rows_to_cm, zip_rows,
+};
+use crate::mamba3_siso::cpu::dims::Mamba3Dims;
+use crate::mamba3_siso::cpu::forward::{
+    heavy_tail, simd_rms_scale, simd_ssm_recurrence, simd_sum_sq, softplus,
+};
+use crate::mamba3_siso::state::Mamba3LayerState;
+use crate::mamba3_siso::weights::{Mamba3LayerWeights, Mamba3Weights};
+use crate::ops::blas::{sgemm_forward, sgemm_forward_par};
+use crate::ops::fast_math::{RMS_NORM_EPS, fast_exp_scalar};
+
+/// Stack-array limits (match `forward.rs` / config validation).
+const MAX_DS: usize = 64;
+const MAX_ANGLES: usize = MAX_DS / 2;
+
+type GemmFn = fn(&mut [f32], &[f32], &[f32], Option<&[f32]>, usize, usize, usize);
+
+/// Three-slice row zip (dst, a, b), serial or rayon-parallel per `mode` —
+/// the gating phase needs the y row AND the proj row per output row.
+fn gate_rows<F>(
+    mode: PrefillMode,
+    dst: (&mut [f32], usize),
+    a: (&[f32], usize),
+    b: (&[f32], usize),
+    f: F,
+) where
+    F: Fn(&mut [f32], &[f32], &[f32]) + Sync + Send,
+{
+    let (dst, dw) = dst;
+    let (a, aw) = a;
+    let (b, bw) = b;
+    match mode {
+        PrefillMode::Single => dst
+            .chunks_mut(dw)
+            .zip(a.chunks(aw))
+            .zip(b.chunks(bw))
+            .for_each(|((d, x), y)| f(d, x, y)),
+        PrefillMode::Parallel => dst
+            .par_chunks_mut(dw)
+            .zip(a.par_chunks(aw))
+            .zip(b.par_chunks(bw))
+            .for_each(|((d, x), y)| f(d, x, y)),
+    }
+}
+
+/// Reusable M3 prefill scratch. `ensure` re-allocates only when the dims
+/// fingerprint changes — zero allocation on the serving hot path once warmed.
+pub struct Mamba3PrefillScratch {
+    fingerprint: (Mamba3Dims, usize),
+    post_norm: Vec<f32>,
+    proj: Vec<f32>,
+    /// BCNormed B/C rows `[T * ngroups * d_state]` (shared reads in F5).
+    b_normed: Vec<f32>,
+    c_normed: Vec<f32>,
+    /// Per-position RoPE angle velocities `tanh(raw) * pi`, `[T * n_angles]`.
+    tanh_pi: Vec<f32>,
+    /// Channel-major x branch `[di * T]`.
+    x_cm: Vec<f32>,
+    /// Head-major scalar columns `[nh * T]`.
+    dd_a_cm: Vec<f32>,
+    dd_dt_cm: Vec<f32>,
+    trap_cm: Vec<f32>,
+    /// SSM output, channel-major `[di * T]` / row-major `[T * di]`.
+    y_cm: Vec<f32>,
+    y_rm: Vec<f32>,
+    gated: Vec<f32>,
+    out: Vec<f32>,
+}
+
+impl Mamba3PrefillScratch {
+    /// Allocate scratch sized for `dims` and `input_dim`.
+    pub fn new(dims: &Mamba3Dims, input_dim: usize) -> Self {
+        let t = dims.seq_len;
+        let di = dims.d_inner;
+        let na = dims.num_rope_angles;
+        Self {
+            fingerprint: (*dims, input_dim),
+            post_norm: vec![0.0; t * dims.d_model],
+            proj: vec![0.0; t * dims.in_proj_dim],
+            b_normed: vec![0.0; t * dims.ngroups * dims.d_state],
+            c_normed: vec![0.0; t * dims.ngroups * dims.d_state],
+            tanh_pi: vec![0.0; t * na.max(1)],
+            x_cm: vec![0.0; di * t],
+            dd_a_cm: vec![0.0; dims.nheads * t],
+            dd_dt_cm: vec![0.0; dims.nheads * t],
+            trap_cm: vec![0.0; dims.nheads * t],
+            y_cm: vec![0.0; di * t],
+            y_rm: vec![0.0; t * di],
+            gated: vec![0.0; t * di],
+            out: vec![0.0; t * dims.d_model],
+        }
+    }
+
+    /// Re-size for a different fingerprint (no-op when unchanged).
+    pub fn ensure(&mut self, dims: &Mamba3Dims, input_dim: usize) {
+        if (*dims, input_dim) != self.fingerprint {
+            *self = Self::new(dims, input_dim);
+        }
+    }
+}
+
+/// F5 for ONE head over the full sequence: input-dependent A/DT, per-head
+/// B/C bias + RoPE, trapezoidal SSM recurrence, D skip. All hot accesses
+/// are head-owned contiguous columns or L2-streamed shared rows. The
+/// per-element expression chains are IDENTICAL to
+/// `forward_mamba3_layer_batched` F5, so the tape-free form is bit-exact.
+struct HeadIo<'a> {
+    y_cols: &'a mut [f32],
+    ssm: &'a mut [f32],
+    k_state: &'a mut [f32],
+    v_state: &'a mut [f32],
+    angle_state: &'a mut [f32],
+}
+
+/// Shared read-only inputs of the F5 head phase (head-major scalar columns
+/// are pre-sliced to THIS head's `[T]` column).
+struct HeadShared<'a> {
+    x_cm: &'a [f32],
+    dd_a_col: &'a [f32],
+    dd_dt_col: &'a [f32],
+    trap_col: &'a [f32],
+    b_normed: &'a [f32],
+    c_normed: &'a [f32],
+    tanh_pi: &'a [f32],
+}
+
+fn ssm_head(
+    h: usize,
+    io: HeadIo<'_>,
+    shared: HeadShared<'_>,
+    lw: &Mamba3LayerWeights,
+    dims: &Mamba3Dims,
+) {
+    let HeadIo {
+        y_cols,
+        ssm,
+        k_state,
+        v_state,
+        angle_state,
+    } = io;
+    let HeadShared {
+        x_cm,
+        dd_a_col,
+        dd_dt_col,
+        trap_col,
+        b_normed,
+        c_normed,
+        tanh_pi,
+    } = shared;
+    let ds = dims.d_state;
+    let hd = dims.headdim;
+    let nh = dims.nheads;
+    let ng = dims.ngroups;
+    let na = dims.num_rope_angles;
+    let t_len = dims.seq_len;
+    let a_floor = dims.a_floor;
+    let g = h / (nh / ng);
+    let gs = g * ds;
+
+    for t in 0..t_len {
+        let a_val = (-heavy_tail(dd_a_col[t])).min(-a_floor);
+        let dt_val = softplus(dd_dt_col[t] + lw.dt_bias[h]);
+
+        let mut k_local = [0.0_f32; MAX_DS];
+        let mut q_local = [0.0_f32; MAX_DS];
+        let b_row = t * ng * ds;
+        for n in 0..ds {
+            k_local[n] = b_normed[b_row + gs + n] + lw.b_bias[h * ds + n];
+            q_local[n] = c_normed[b_row + gs + n] + lw.c_bias[h * ds + n];
+        }
+
+        if na > 0 {
+            let tp_row = t * na;
+            for (an, &tp) in angle_state[..na]
+                .iter_mut()
+                .zip(&tanh_pi[tp_row..tp_row + na])
+            {
+                let delta = tp * dt_val;
+                let mut acc = *an as f64 + delta as f64;
+                let two_pi_64 = 2.0 * std::f64::consts::PI;
+                acc -= two_pi_64 * (acc / two_pi_64).floor();
+                *an = acc as f32;
+            }
+            for (a, an) in angle_state[..na].iter().enumerate() {
+                let (sin_a, cos_a) = an.sin_cos();
+                let i0 = 2 * a;
+                let i1 = 2 * a + 1;
+                let b0 = k_local[i0];
+                let b1 = k_local[i1];
+                k_local[i0] = cos_a * b0 - sin_a * b1;
+                k_local[i1] = sin_a * b0 + cos_a * b1;
+                let c0 = q_local[i0];
+                let c1 = q_local[i1];
+                q_local[i0] = cos_a * c0 - sin_a * c1;
+                q_local[i1] = sin_a * c0 + cos_a * c1;
+            }
+        }
+
+        let alpha = fast_exp_scalar(a_val * dt_val);
+        let trap_sig = 1.0 / (1.0 + fast_exp_scalar(-trap_col[t]));
+        let beta = alpha * dt_val * (1.0 - trap_sig);
+        let gamma = trap_sig * dt_val;
+
+        for p in 0..hd {
+            let x_val = x_cm[(h * hd + p) * t_len + t];
+            let v_prev = v_state[p];
+            let s_off = p * ds;
+            let y_val = simd_ssm_recurrence(
+                &mut ssm[s_off..s_off + ds],
+                &k_state[..ds],
+                &k_local[..ds],
+                &q_local[..ds],
+                alpha,
+                beta * v_prev,
+                gamma * x_val,
+            );
+            y_cols[p * t_len + t] = lw.d_param[h].mul_add(x_val, y_val);
+        }
+
+        k_state[..ds].copy_from_slice(&k_local[..ds]);
+        for p in 0..hd {
+            v_state[p] = x_cm[(h * hd + p) * t_len + t];
+        }
+    }
+}
+
+/// Full-sequence Mamba-3 CPU inference forward (serial mode).
+///
+/// - `temporal_out`: `[T * d_model]` — POST-norm_f output at EVERY position.
+/// - `input_flat`: `[T * input_dim]`.
+/// - `states`: one [`Mamba3LayerState`] per layer, carried in AND out
+///   (prefill-then-decode into [`super::inference::mamba3_step`]).
+pub fn forward_mamba3_backbone_prefill(
+    temporal_out: &mut [f32],
+    input_flat: &[f32],
+    w: &Mamba3Weights,
+    states: &mut [Mamba3LayerState],
+    scratch: &mut Mamba3PrefillScratch,
+    dims: &Mamba3Dims,
+) {
+    forward_mamba3_backbone_prefill_mode(
+        temporal_out,
+        input_flat,
+        w,
+        states,
+        scratch,
+        dims,
+        PrefillMode::Single,
+    );
+}
+
+/// [`forward_mamba3_backbone_prefill`] with an explicit execution mode.
+pub fn forward_mamba3_backbone_prefill_mode(
+    temporal_out: &mut [f32],
+    input_flat: &[f32],
+    w: &Mamba3Weights,
+    states: &mut [Mamba3LayerState],
+    scratch: &mut Mamba3PrefillScratch,
+    dims: &Mamba3Dims,
+    mode: PrefillMode,
+) {
+    let dm = dims.d_model;
+    let di = dims.d_inner;
+    let ds = dims.d_state;
+    let nh = dims.nheads;
+    let hd = dims.headdim;
+    let ng = dims.ngroups;
+    let ip = dims.in_proj_dim;
+    let na = dims.num_rope_angles;
+    let t_len = dims.seq_len;
+    let is_outproj_norm = dims.is_outproj_norm;
+    let t_dm = t_len * dm;
+
+    assert!(ds <= MAX_DS, "d_state > {MAX_DS} unsupported");
+    assert!(
+        na <= MAX_ANGLES,
+        "num_rope_angles > {MAX_ANGLES} unsupported"
+    );
+    assert_eq!(temporal_out.len(), t_dm, "temporal_out shape");
+    assert_eq!(states.len(), dims.n_layers, "state layer count");
+    let input_dim = if w.input_proj_w.is_empty() {
+        dm
+    } else {
+        w.input_proj_w.len() / dm
+    };
+    assert_eq!(input_flat.len(), t_len * input_dim, "input shape");
+    scratch.ensure(dims, input_dim);
+
+    let gemm: GemmFn = match mode {
+        PrefillMode::Single => sgemm_forward,
+        PrefillMode::Parallel => sgemm_forward_par,
+    };
+
+    // Input projection (identity D2D when input_proj is absent — the
+    // mixed-trained checkpoint convention).
+    if w.input_proj_w.is_empty() {
+        temporal_out[..t_dm].copy_from_slice(&input_flat[..t_dm]);
+    } else {
+        gemm(
+            temporal_out,
+            input_flat,
+            &w.input_proj_w,
+            Some(&w.input_proj_b),
+            t_len,
+            input_dim,
+            dm,
+        );
+    }
+
+    for (layer_idx, lw) in w.layers.iter().enumerate() {
+        let lstate = &mut states[layer_idx];
+
+        // F1: RMSNorm rows (temporal_out doubles as the residual — read
+        // here, updated in place at F7).
+        zip_rows(
+            mode,
+            (&mut scratch.post_norm[..t_dm], dm),
+            (&temporal_out[..t_dm], dm),
+            |dst, src| {
+                let sum_sq = simd_sum_sq(src);
+                let inv_rms = 1.0 / (sum_sq / dm as f32 + RMS_NORM_EPS).sqrt();
+                simd_rms_scale(dst, src, &lw.norm_weight[..dm], inv_rms);
+            },
+        );
+
+        // F2: in_proj GEMM.
+        gemm(
+            &mut scratch.proj,
+            &scratch.post_norm,
+            &lw.in_proj_w,
+            None,
+            t_len,
+            dm,
+            ip,
+        );
+
+        // F3/F4 prep rows: BCNorm B and C + tanh-pi angle velocities. The
+        // 8-way split stays implicit — later phases read `proj` columns
+        // directly (row-sequential) or via the blocked transposes below.
+        let bsize = ng * ds;
+        let (b_off, c_off) = (2 * di, 2 * di + bsize);
+        let angles_off = 2 * di + 2 * bsize + 3 * nh;
+        zip_rows(
+            mode,
+            (&mut scratch.b_normed[..t_len * bsize], bsize),
+            (&scratch.proj[..t_len * ip], ip),
+            |dst, proj_row| {
+                for g in 0..ng {
+                    let raw = &proj_row[b_off + g * ds..b_off + g * ds + ds];
+                    let sum_sq = simd_sum_sq(raw);
+                    let inv_rms = 1.0 / (sum_sq / ds as f32 + RMS_NORM_EPS).sqrt();
+                    for (i, (d, &r)) in dst[g * ds..g * ds + ds].iter_mut().zip(raw).enumerate() {
+                        *d = r * inv_rms * lw.b_norm_weight[i];
+                    }
+                }
+            },
+        );
+        zip_rows(
+            mode,
+            (&mut scratch.c_normed[..t_len * bsize], bsize),
+            (&scratch.proj[..t_len * ip], ip),
+            |dst, proj_row| {
+                for g in 0..ng {
+                    let raw = &proj_row[c_off + g * ds..c_off + g * ds + ds];
+                    let sum_sq = simd_sum_sq(raw);
+                    let inv_rms = 1.0 / (sum_sq / ds as f32 + RMS_NORM_EPS).sqrt();
+                    for (i, (d, &r)) in dst[g * ds..g * ds + ds].iter_mut().zip(raw).enumerate() {
+                        *d = r * inv_rms * lw.c_norm_weight[i];
+                    }
+                }
+            },
+        );
+        if na > 0 {
+            let pi = std::f32::consts::PI;
+            zip_rows(
+                mode,
+                (&mut scratch.tanh_pi[..t_len * na], na),
+                (&scratch.proj[..t_len * ip], ip),
+                |dst, proj_row| {
+                    for (d, &raw) in dst.iter_mut().zip(&proj_row[angles_off..angles_off + na]) {
+                        *d = raw.tanh() * pi;
+                    }
+                },
+            );
+        }
+
+        // Blocked transposes: x branch to channel-major, head scalars to
+        // head-major (the F5 head loops must never stride through `proj`).
+        transpose_rows_to_cm(&mut scratch.x_cm, &scratch.proj, di, t_len, (ip, di), mode);
+        let sc_off = 2 * di + 2 * bsize;
+        transpose_rows_to_cm(
+            &mut scratch.dd_dt_cm,
+            &scratch.proj,
+            nh,
+            t_len,
+            (ip, sc_off),
+            mode,
+        );
+        transpose_rows_to_cm(
+            &mut scratch.dd_a_cm,
+            &scratch.proj,
+            nh,
+            t_len,
+            (ip, sc_off + nh),
+            mode,
+        );
+        transpose_rows_to_cm(
+            &mut scratch.trap_cm,
+            &scratch.proj,
+            nh,
+            t_len,
+            (ip, sc_off + 2 * nh),
+            mode,
+        );
+
+        // F5: trapezoidal SSM, one task per head (disjoint state + y cols).
+        {
+            let x_cm = &scratch.x_cm[..];
+            let dd_a_cm = &scratch.dd_a_cm[..];
+            let dd_dt_cm = &scratch.dd_dt_cm[..];
+            let trap_cm = &scratch.trap_cm[..];
+            let b_normed = &scratch.b_normed[..];
+            let c_normed = &scratch.c_normed[..];
+            let tanh_pi = &scratch.tanh_pi[..];
+            let na_st = na.max(1);
+            let run_head = |h: usize, io: HeadIo<'_>| {
+                ssm_head(
+                    h,
+                    io,
+                    HeadShared {
+                        x_cm,
+                        dd_a_col: &dd_a_cm[h * t_len..(h + 1) * t_len],
+                        dd_dt_col: &dd_dt_cm[h * t_len..(h + 1) * t_len],
+                        trap_col: &trap_cm[h * t_len..(h + 1) * t_len],
+                        b_normed,
+                        c_normed,
+                        tanh_pi,
+                    },
+                    lw,
+                    dims,
+                );
+            };
+            match mode {
+                PrefillMode::Single => {
+                    for (h, ((((y_cols, ssm), k_st), v_st), an_st)) in scratch
+                        .y_cm
+                        .chunks_mut(hd * t_len)
+                        .zip(lstate.ssm_state.chunks_mut(hd * ds))
+                        .zip(lstate.k_state.chunks_mut(ds))
+                        .zip(lstate.v_state.chunks_mut(hd))
+                        .zip(lstate.angle_state.chunks_mut(na_st))
+                        .enumerate()
+                    {
+                        run_head(
+                            h,
+                            HeadIo {
+                                y_cols,
+                                ssm,
+                                k_state: k_st,
+                                v_state: v_st,
+                                angle_state: an_st,
+                            },
+                        );
+                    }
+                }
+                PrefillMode::Parallel => {
+                    scratch
+                        .y_cm
+                        .par_chunks_mut(hd * t_len)
+                        .zip(lstate.ssm_state.par_chunks_mut(hd * ds))
+                        .zip(lstate.k_state.par_chunks_mut(ds))
+                        .zip(lstate.v_state.par_chunks_mut(hd))
+                        .zip(lstate.angle_state.par_chunks_mut(na_st))
+                        .enumerate()
+                        .for_each(|(h, ((((y_cols, ssm), k_st), v_st), an_st))| {
+                            run_head(
+                                h,
+                                HeadIo {
+                                    y_cols,
+                                    ssm,
+                                    k_state: k_st,
+                                    v_state: v_st,
+                                    angle_state: an_st,
+                                },
+                            );
+                        });
+                }
+            }
+        }
+        transpose_cm_to_rm(&mut scratch.y_rm, &scratch.y_cm, di, t_len, mode);
+
+        // F6: output gating rows (z read row-sequentially from proj).
+        gate_rows(
+            mode,
+            (&mut scratch.gated[..t_len * di], di),
+            (&scratch.y_rm[..t_len * di], di),
+            (&scratch.proj[..t_len * ip], ip),
+            |gated_row, y_row, proj_row| {
+                let z_row = &proj_row[..di];
+                if is_outproj_norm {
+                    for g_start in (0..di).step_by(hd) {
+                        let g_end = (g_start + hd).min(di);
+                        let g_len = g_end - g_start;
+                        let sum_sq = simd_sum_sq(&y_row[g_start..g_end]);
+                        let rstd = 1.0 / (sum_sq / g_len as f32 + RMS_NORM_EPS).sqrt();
+                        for d in g_start..g_end {
+                            let z = z_row[d];
+                            let silu = z / (1.0 + fast_exp_scalar(-z));
+                            gated_row[d] = y_row[d] * rstd * lw.norm_gate_weight[d] * silu;
+                        }
+                    }
+                } else {
+                    for ((gv, &y), &z) in gated_row.iter_mut().zip(y_row).zip(z_row) {
+                        let silu = z / (1.0 + fast_exp_scalar(-z));
+                        *gv = y * silu;
+                    }
+                }
+            },
+        );
+
+        // F7: out_proj GEMM + in-place residual add.
+        gemm(
+            &mut scratch.out,
+            &scratch.gated,
+            &lw.out_proj_w,
+            None,
+            t_len,
+            di,
+            dm,
+        );
+        zip_rows(
+            mode,
+            (&mut temporal_out[..t_dm], dm),
+            (&scratch.out[..t_dm], dm),
+            |y_row, o_row| {
+                for (y, &o) in y_row.iter_mut().zip(o_row) {
+                    *y += o;
+                }
+            },
+        );
+    }
+
+    // norm_f at EVERY position, via the public in-place RMSNorm (the anchor
+    // test reproduces the exact same call per row).
+    for_rows(mode, &mut temporal_out[..t_dm], dm, |row| {
+        crate::ops::norms::rms_norm_inplace(row, &w.norm_f_weight[..dm], RMS_NORM_EPS);
+    });
+}
+
+/// Prefill a batch of independent sequences in parallel (one rayon task per
+/// sample, each running [`PrefillMode::Single`] internally — the M3 twin of
+/// [`crate::mamba_ssm::cpu::prefill::prefill_batch`]).
+pub fn prefill3_batch(
+    outputs: &mut [f32],
+    inputs: &[f32],
+    w: &Mamba3Weights,
+    states: &mut [crate::mamba3_siso::state::Mamba3State],
+    scratches: &mut [Mamba3PrefillScratch],
+    dims: &Mamba3Dims,
+) {
+    let t_len = dims.seq_len;
+    let dm = dims.d_model;
+    let b = states.len();
+    let input_dim = if w.input_proj_w.is_empty() {
+        dm
+    } else {
+        w.input_proj_w.len() / dm
+    };
+    assert_eq!(scratches.len(), b, "one scratch per sample");
+    assert_eq!(outputs.len(), b * t_len * dm, "outputs shape");
+    assert_eq!(inputs.len(), b * t_len * input_dim, "inputs shape");
+
+    outputs
+        .par_chunks_mut(t_len * dm)
+        .zip(states.par_iter_mut())
+        .zip(scratches.par_iter_mut())
+        .enumerate()
+        .for_each(|(i, ((out, state), scratch))| {
+            let inp = &inputs[i * t_len * input_dim..(i + 1) * t_len * input_dim];
+            forward_mamba3_backbone_prefill(out, inp, w, &mut state.layers, scratch, dims);
+        });
+}

--- a/src/mamba3_siso/gpu/trainer.rs
+++ b/src/mamba3_siso/gpu/trainer.rs
@@ -175,6 +175,28 @@ impl Mamba3Trainer {
         }
     }
 
+    /// Toggle the reference-faithful AdamW no-decay parameter groups
+    /// (dt bias / `d_param` / every norm scale get `weight_decay = 0`).
+    /// Default OFF preserves the historical behavior bit-for-bit. Errs
+    /// while a captured graph exists (the decay coefficient is baked by
+    /// value into the captured per-tensor launches). Mirrors
+    /// `MambaTrainer::set_reference_no_decay`.
+    pub fn set_reference_no_decay(&mut self, on: bool) -> Result<(), String> {
+        if self.has_graph() {
+            return Err(
+                "set_reference_no_decay under a captured graph: the decay coefficient \
+                 is baked by value into the captured AdamW launches — drop_graph() \
+                 first, then toggle, then re-capture"
+                    .into(),
+            );
+        }
+        match &mut self.inner {
+            Trainer3Inner::F32(t) => t.adam.reference_no_decay = on,
+            Trainer3Inner::Mixed(t) => t.adam.reference_no_decay = on,
+        }
+        Ok(())
+    }
+
     /// Drop any captured step graph so `drop_graph -> set_lr ->
     /// capture_graph` is expressible. Mirrors `MambaTrainer::drop_graph`.
     pub fn drop_graph(&mut self) {

--- a/src/mamba3_siso/gpu/trainer.rs
+++ b/src/mamba3_siso/gpu/trainer.rs
@@ -10,16 +10,19 @@
 use cudarc::driver::PushKernelArg;
 
 use crate::mamba_ssm::gpu::adamw::{AdamWBiasFactors, GpuAdamW, step_m3_capturable};
-use crate::mamba_ssm::gpu::buffers::GpuBuffer;
+use crate::mamba_ssm::gpu::buffers::{GpuBuffer, GpuByteBuffer};
 use crate::mamba_ssm::gpu::context::GpuCtx;
 use crate::mamba_ssm::gpu::device::GpuDevice;
 use crate::mamba_ssm::gpu::dtype::WeightDtype;
+use crate::mamba_ssm::gpu::grad_clip::{
+    GRAD_CLIP_PARTIALS, alloc_partials, global_grad_norm, scale_grads,
+};
 use crate::mamba_ssm::gpu::graph_capture::capture_into_graph;
 use crate::mamba_ssm::gpu::loss_scaler::{
     DynamicLossScaler, OverflowFlag, UnscaleFactor, check_inf_nan_gpu, scale_grads_skip_gpu,
 };
 use crate::mamba_ssm::gpu::trainer::StepMetrics;
-pub use crate::mamba_ssm::gpu::trainer::TrainSessionCfg;
+pub use crate::mamba_ssm::gpu::trainer::{BackwardMetrics, BackwardOpts, TrainSessionCfg};
 use crate::mamba3_siso::config::Mamba3Config;
 use crate::mamba3_siso::gpu::backward::gpu_backward_mamba3_backbone;
 use crate::mamba3_siso::gpu::backward_mixed::gpu_backward_mamba3_backbone_mixed;
@@ -236,6 +239,35 @@ impl Mamba3Trainer {
         }
     }
 
+    /// Eager forward half of the split step — M3 mirror of
+    /// [`crate::mamba_ssm::gpu::trainer::MambaTrainer::forward`]: runs the
+    /// training forward and writes the FULL `batch * seq_len * d_model`
+    /// POST-norm_f temporal output into caller-owned `temporal_out` (f32 on
+    /// all dtypes). Stream-synchronized on return. Advances the recurrent
+    /// state; always eager (see the M1 doc for the graph rationale — the
+    /// fused [`Self::step`] composes the same eager bodies).
+    pub fn forward(&mut self, input: &[f32], temporal_out: &mut [f32]) -> Result<(), String> {
+        match &mut self.inner {
+            Trainer3Inner::F32(t) => t.forward_split(input, temporal_out),
+            Trainer3Inner::Mixed(t) => t.forward_split(input, temporal_out),
+        }
+    }
+
+    /// Backward + optimizer half of the split step — M3 mirror of
+    /// [`crate::mamba_ssm::gpu::trainer::MambaTrainer::backward_step`].
+    /// `d_temporal` is the gradient w.r.t. the IMMEDIATELY PRECEDING
+    /// [`Self::forward`]'s temporal output. Errs when no forward is pending.
+    pub fn backward_step(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        match &mut self.inner {
+            Trainer3Inner::F32(t) => t.backward_split(d_temporal, opts),
+            Trainer3Inner::Mixed(t) => t.backward_split(d_temporal, opts),
+        }
+    }
+
     /// Download f32 master weights for checkpointing.
     pub fn snapshot_master(&self) -> Result<Mamba3Weights, String> {
         match &self.inner {
@@ -289,6 +321,17 @@ pub(crate) struct Mamba3TrainerMixed {
     angle_states: GpuBuffer,
 
     graph: Option<GpuMamba3TrainingStepGraph>,
+
+    /// True between a `forward_split` and the `backward_split` consuming its
+    /// saved activations (the split-API staleness interlock).
+    split_forward_pending: bool,
+    /// True while the grad arena holds accumulated (un-applied) gradients
+    /// from `accumulate_only` backward calls — the next backward must NOT
+    /// zero the arena.
+    grads_dirty: bool,
+    /// Fixed-size f64 partials for the deterministic global grad norm.
+    clip_partials: GpuByteBuffer,
+    clip_partials_host: Vec<f64>,
 
     // f16 AMP loss scaler (None for bf16). See M1 trainer for the protocol.
     scaler: Option<DynamicLossScaler>,
@@ -414,6 +457,8 @@ impl Mamba3TrainerMixed {
             .synchronize()
             .map_err(|e| format!("sync: {e:?}"))?;
 
+        let clip_partials = alloc_partials(&ctx.stream)?;
+
         Ok(Self {
             ctx,
             m3k,
@@ -435,6 +480,10 @@ impl Mamba3TrainerMixed {
             v_states,
             angle_states,
             graph: None,
+            split_forward_pending: false,
+            grads_dirty: false,
+            clip_partials,
+            clip_partials_host: vec![0.0; GRAD_CLIP_PARTIALS],
             scaler,
             overflow_flag,
             d_temporal_scaled,
@@ -506,6 +555,14 @@ impl Mamba3TrainerMixed {
             self.d_temporal.len(),
             "d_temporal shape mismatch"
         );
+        if self.grads_dirty {
+            return Err(
+                "step(): an accumulate_only backward window is open — close it with \
+                 backward_step(accumulate_only=false); the fused step zeroes the grad \
+                 arena and would silently discard the accumulated gradients"
+                    .into(),
+            );
+        }
 
         if matches!(self.dtype, WeightDtype::F16) {
             return self.step_f16(input, d_temporal);
@@ -618,35 +675,11 @@ impl Mamba3TrainerMixed {
             self.scaler.as_mut().expect("f16 scaler").update(overflow);
             (next_step, overflow, true)
         } else {
+            // Same op sequence as the captured graph body (composed from
+            // the shared eager phase bodies).
             self.grads.zero(&self.ctx.stream)?;
-            let exec = M3Exec {
-                ctx: &self.ctx,
-                kernels: &self.m3k,
-                dims: &self.dims,
-            };
-            gpu_forward_mamba3_backbone_mixed(
-                &exec,
-                &mut self.temporal,
-                &mut self.acts,
-                &self.weights,
-                &self.mamba_input,
-                GpuMamba3StateBufs {
-                    ssm: &mut self.ssm_states,
-                    k: &mut self.k_states,
-                    v: &mut self.v_states,
-                    angle: &mut self.angle_states,
-                },
-                &mut self.mixed_scratch,
-            )?;
-            gpu_backward_mamba3_backbone_mixed(
-                &exec,
-                dt_scaled,
-                &self.acts,
-                &self.weights,
-                &self.grads,
-                &mut self.f32_scratch,
-                &mut self.mixed_scratch,
-            )?;
+            self.eager_forward()?;
+            self.eager_backward(true)?;
             check_inf_nan_gpu(
                 &self.ctx,
                 &self.ctx.kernels,
@@ -661,15 +694,7 @@ impl Mamba3TrainerMixed {
                 &mut self.grads.flat,
                 unscale,
             )?;
-            step_m3_capturable(
-                &self.ctx,
-                &self.m3k.adamw_step_f32_capturable,
-                &self.adam,
-                self.bias.ptr(),
-                &mut self.weights.master,
-                &self.grads,
-            )?;
-            self.weights.sync_master_to_compute(&self.ctx)?;
+            self.eager_optimize()?;
             let overflow = self
                 .overflow_flag
                 .as_ref()
@@ -731,37 +756,13 @@ impl Mamba3TrainerMixed {
         let snap_grads = self.grads.flat.cached_ptr();
         let snap_dt_scaled = self.d_temporal_scaled.as_ref().unwrap().cached_ptr();
 
+        // Capture body: mirrors the eager f16 path 1:1 (composed from the
+        // shared eager phase bodies) so numerics match.
         let stream = self.ctx.stream.clone();
         let g = capture_into_graph(&stream, || {
             self.grads.zero(&self.ctx.stream)?;
-            let exec = M3Exec {
-                ctx: &self.ctx,
-                kernels: &self.m3k,
-                dims: &self.dims,
-            };
-            gpu_forward_mamba3_backbone_mixed(
-                &exec,
-                &mut self.temporal,
-                &mut self.acts,
-                &self.weights,
-                &self.mamba_input,
-                GpuMamba3StateBufs {
-                    ssm: &mut self.ssm_states,
-                    k: &mut self.k_states,
-                    v: &mut self.v_states,
-                    angle: &mut self.angle_states,
-                },
-                &mut self.mixed_scratch,
-            )?;
-            gpu_backward_mamba3_backbone_mixed(
-                &exec,
-                self.d_temporal_scaled.as_mut().unwrap(),
-                &self.acts,
-                &self.weights,
-                &self.grads,
-                &mut self.f32_scratch,
-                &mut self.mixed_scratch,
-            )?;
+            self.eager_forward()?;
+            self.eager_backward(true)?;
             check_inf_nan_gpu(
                 &self.ctx,
                 &self.ctx.kernels,
@@ -775,15 +776,7 @@ impl Mamba3TrainerMixed {
                 &mut self.grads.flat,
                 self.unscale_factor.as_ref().unwrap(),
             )?;
-            step_m3_capturable(
-                &self.ctx,
-                &self.m3k.adamw_step_f32_capturable,
-                &self.adam,
-                self.bias.ptr(),
-                &mut self.weights.master,
-                &self.grads,
-            )?;
-            self.weights.sync_master_to_compute(&self.ctx)?;
+            self.eager_optimize()?;
             Ok(())
         })?;
         self.graph_f16 = Some(g);
@@ -795,8 +788,11 @@ impl Mamba3TrainerMixed {
         Ok(())
     }
 
-    fn step_eager(&mut self) -> Result<(), String> {
-        self.grads.zero(&self.ctx.stream)?;
+    /// Eager forward body: run the mixed training forward, writing the f32
+    /// post-norm_f output into `self.temporal`. One of the three shared
+    /// phase bodies the fused eager step, the f16 paths, and the
+    /// forward/backward split all compose (M1 seam mirror).
+    fn eager_forward(&mut self) -> Result<(), String> {
         let exec = M3Exec {
             ctx: &self.ctx,
             kernels: &self.m3k,
@@ -815,16 +811,41 @@ impl Mamba3TrainerMixed {
                 angle: &mut self.angle_states,
             },
             &mut self.mixed_scratch,
-        )?;
+        )
+    }
+
+    /// Eager backward body: accumulate gradients into the grad arena
+    /// (beta=1.0 — zeroing is the caller's responsibility). `scaled` selects
+    /// the f16 loss-scaled `d_temporal_scaled` buffer over the plain
+    /// `d_temporal` upload buffer.
+    fn eager_backward(&mut self, scaled: bool) -> Result<(), String> {
+        let exec = M3Exec {
+            ctx: &self.ctx,
+            kernels: &self.m3k,
+            dims: &self.dims,
+        };
+        let d_temporal = if scaled {
+            self.d_temporal_scaled
+                .as_mut()
+                .expect("eager_backward(scaled): f16 d_temporal_scaled missing")
+        } else {
+            &mut self.d_temporal
+        };
         gpu_backward_mamba3_backbone_mixed(
             &exec,
-            &mut self.d_temporal,
+            d_temporal,
             &self.acts,
             &self.weights,
             &self.grads,
             &mut self.f32_scratch,
             &mut self.mixed_scratch,
-        )?;
+        )
+    }
+
+    /// Eager optimizer tail: AdamW on the f32 master weights (capturable
+    /// kernel so graph and eager numerics stay bit-identical), then the
+    /// master → compute sync.
+    fn eager_optimize(&mut self) -> Result<(), String> {
         step_m3_capturable(
             &self.ctx,
             &self.m3k.adamw_step_f32_capturable,
@@ -833,8 +854,224 @@ impl Mamba3TrainerMixed {
             &mut self.weights.master,
             &self.grads,
         )?;
-        self.weights.sync_master_to_compute(&self.ctx)?;
+        self.weights.sync_master_to_compute(&self.ctx)
+    }
+
+    fn step_eager(&mut self) -> Result<(), String> {
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_forward()?;
+        self.eager_backward(false)?;
+        self.eager_optimize()
+    }
+
+    /// Split forward (see [`Mamba3Trainer::forward`]). The M3 mixed forward
+    /// already writes f32 temporal — no upcast staging needed (unlike M1).
+    pub(crate) fn forward_split(
+        &mut self,
+        input: &[f32],
+        temporal_out: &mut [f32],
+    ) -> Result<(), String> {
+        assert_eq!(
+            input.len(),
+            self.mamba_input.len(),
+            "input shape mismatch: expected batch*seq_len*input_dim={}, got {}",
+            self.mamba_input.len(),
+            input.len(),
+        );
+        assert_eq!(
+            temporal_out.len(),
+            self.temporal.len(),
+            "temporal_out shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.temporal.len(),
+            temporal_out.len(),
+        );
+        self.mamba_input.upload(&self.ctx.stream, input)?;
+        self.eager_forward()?;
+        self.ctx
+            .stream
+            .synchronize()
+            .map_err(|e| format!("forward_split sync: {e:?}"))?;
+        self.temporal.download(&self.ctx.stream, temporal_out)?;
+        self.split_forward_pending = true;
         Ok(())
+    }
+
+    /// Split backward + optimizer (see [`Mamba3Trainer::backward_step`]).
+    pub(crate) fn backward_split(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        if !self.split_forward_pending {
+            return Err(
+                "backward_step() without a pending forward() — the saved activations \
+                 are stale or missing; call forward() first"
+                    .into(),
+            );
+        }
+        if opts.clip_max_norm.is_some() && opts.accumulate_only {
+            return Err(
+                "clip_max_norm + accumulate_only is unsupported: the global norm is only \
+                 defined over the COMPLETE accumulated gradient — request the clip on the \
+                 final (applying) backward_step"
+                    .into(),
+            );
+        }
+        assert_eq!(
+            d_temporal.len(),
+            self.d_temporal.len(),
+            "d_temporal shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.d_temporal.len(),
+            d_temporal.len(),
+        );
+
+        if matches!(self.dtype, WeightDtype::F16) {
+            if opts.accumulate_only {
+                return Err(
+                    "f16 + accumulate_only is unsupported: the loss-scale freeze window \
+                     across micro-batches has no defined semantics"
+                        .into(),
+                );
+            }
+            let m = self.backward_split_f16(d_temporal, opts.clip_max_norm)?;
+            self.split_forward_pending = false;
+            return Ok(m);
+        }
+
+        self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
+        if !self.grads_dirty {
+            self.grads.zero(&self.ctx.stream)?;
+        }
+        self.eager_backward(false)?;
+        self.split_forward_pending = false;
+
+        if opts.accumulate_only {
+            self.grads_dirty = true;
+            Ok(BackwardMetrics {
+                step: self.adam.step,
+                optimizer_stepped: false,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        } else {
+            let grad_norm = match opts.clip_max_norm {
+                Some(c) => Some(self.apply_clip(c)?),
+                None => None,
+            };
+            let (step, bc1, bc2) = self.adam.advance();
+            self.bias.write(&self.ctx.stream, bc1, bc2)?;
+            self.eager_optimize()?;
+            self.grads_dirty = false;
+            Ok(BackwardMetrics {
+                step,
+                optimizer_stepped: true,
+                grad_norm,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        }
+    }
+
+    /// f16 split backward: GradScaler protocol minus the forward — scale,
+    /// backward, overflow check, conditional unscale + clip + optimize,
+    /// scaler update, step rollback. Clip norm is computed AFTER the
+    /// unscale (the unscale-then-norm-then-clip ordering law). M1 mirror.
+    fn backward_split_f16(
+        &mut self,
+        d_temporal: &[f32],
+        clip_max_norm: Option<f32>,
+    ) -> Result<BackwardMetrics, String> {
+        let scale = self.scaler.as_ref().expect("f16 scaler").scale();
+        {
+            let dt_scaled = self.d_temporal_scaled.as_mut().expect("f16 dt_scaled");
+            dt_scaled.upload(&self.ctx.stream, d_temporal)?;
+            let n = d_temporal.len() as i32;
+            let mut builder = self
+                .ctx
+                .stream
+                .launch_builder(&self.ctx.kernels.scale_grads_f32);
+            builder.arg(dt_scaled.inner_mut());
+            builder.arg(&scale);
+            builder.arg(&n);
+            unsafe { builder.launch(crate::mamba_ssm::gpu::launch::grid_1d(d_temporal.len())) }
+                .map_err(|e| format!("scale d_temporal (m3 f16 split): {e:?}"))?;
+        }
+        if let Some(ref mut u) = self.unscale_factor {
+            u.write(&self.ctx.stream, 1.0 / scale)?;
+        }
+        let prev_step = self.adam.step;
+        let (next_step, bc1, bc2) = self.adam.advance();
+        self.bias.write(&self.ctx.stream, bc1, bc2)?;
+        self.overflow_flag
+            .as_mut()
+            .expect("f16 overflow flag")
+            .zero(&self.ctx.stream)?;
+
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_backward(true)?;
+        check_inf_nan_gpu(
+            &self.ctx,
+            &self.ctx.kernels,
+            self.overflow_flag.as_mut().unwrap(),
+            &self.grads.flat,
+        )?;
+        let overflow = self
+            .overflow_flag
+            .as_ref()
+            .unwrap()
+            .read(&self.ctx.stream)?
+            != 0;
+        let mut grad_norm = None;
+        if !overflow {
+            let unscale = self.unscale_factor.as_ref().expect("unscale buf");
+            scale_grads_skip_gpu(
+                &self.ctx,
+                &self.ctx.kernels,
+                self.overflow_flag.as_mut().unwrap(),
+                &mut self.grads.flat,
+                unscale,
+            )?;
+            if let Some(c) = clip_max_norm {
+                grad_norm = Some(self.apply_clip(c)?);
+            }
+            self.eager_optimize()?;
+        }
+        self.scaler.as_mut().expect("f16 scaler").update(overflow);
+        let final_step = if overflow {
+            self.adam.step = prev_step;
+            prev_step
+        } else {
+            next_step
+        };
+        Ok(BackwardMetrics {
+            step: final_step,
+            optimizer_stepped: !overflow,
+            grad_norm,
+            loss_scale: Some(scale),
+            overflow_skipped: Some(overflow),
+        })
+    }
+
+    /// Compute the deterministic global grad norm, apply the clip
+    /// coefficient when needed, and return the PRE-clip norm.
+    fn apply_clip(&mut self, max_norm: f32) -> Result<f32, String> {
+        let norm = global_grad_norm(
+            &self.ctx,
+            &self.grads.flat,
+            &mut self.clip_partials,
+            &mut self.clip_partials_host,
+        )?;
+        if !norm.is_finite() {
+            return Err(format!(
+                "clip_max_norm: non-finite global grad norm ({norm})"
+            ));
+        }
+        let coef = max_norm as f64 / (norm + 1e-6);
+        if coef < 1.0 {
+            scale_grads(&self.ctx, &mut self.grads.flat, coef as f32)?;
+        }
+        Ok(norm as f32)
     }
 
     /// Download master weights to CPU for checkpointing.
@@ -908,6 +1145,15 @@ pub(crate) struct Mamba3TrainerF32 {
     v_states: GpuBuffer,
     angle_states: GpuBuffer,
     graph: Option<GpuMamba3F32TrainingStepGraph>,
+    /// True between a `forward_split` and the `backward_split` consuming its
+    /// saved activations (the split-API staleness interlock).
+    split_forward_pending: bool,
+    /// True while the grad arena holds accumulated (un-applied) gradients
+    /// from `accumulate_only` backward calls.
+    grads_dirty: bool,
+    /// Fixed-size f64 partials for the deterministic global grad norm.
+    clip_partials: GpuByteBuffer,
+    clip_partials_host: Vec<f64>,
 }
 
 impl Mamba3TrainerF32 {
@@ -977,6 +1223,8 @@ impl Mamba3TrainerF32 {
             .synchronize()
             .map_err(|e| format!("sync: {e:?}"))?;
 
+        let clip_partials = alloc_partials(&ctx.stream)?;
+
         Ok(Self {
             ctx,
             m3k,
@@ -996,6 +1244,10 @@ impl Mamba3TrainerF32 {
             v_states,
             angle_states,
             graph: None,
+            split_forward_pending: false,
+            grads_dirty: false,
+            clip_partials,
+            clip_partials_host: vec![0.0; GRAD_CLIP_PARTIALS],
         })
     }
 
@@ -1044,6 +1296,14 @@ impl Mamba3TrainerF32 {
             self.d_temporal.len(),
             "d_temporal shape mismatch"
         );
+        if self.grads_dirty {
+            return Err(
+                "step(): an accumulate_only backward window is open — close it with \
+                 backward_step(accumulate_only=false); the fused step zeroes the grad \
+                 arena and would silently discard the accumulated gradients"
+                    .into(),
+            );
+        }
         self.mamba_input.upload(&self.ctx.stream, input)?;
         self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
         let (step, bc1, bc2) = self.adam.advance();
@@ -1070,8 +1330,9 @@ impl Mamba3TrainerF32 {
         Ok(StepMetrics::plain(step, replayed))
     }
 
-    fn step_eager(&mut self) -> Result<(), String> {
-        self.grads.zero(&self.ctx.stream)?;
+    /// Eager forward body (M1 seam mirror — the split API and the fused
+    /// eager step compose exactly these bodies).
+    fn eager_forward(&mut self) -> Result<(), String> {
         let exec = M3Exec {
             ctx: &self.ctx,
             kernels: &self.m3k,
@@ -1090,7 +1351,17 @@ impl Mamba3TrainerF32 {
                 angle: &mut self.angle_states,
             },
             &mut self.scratch,
-        )?;
+        )
+    }
+
+    /// Eager backward body: accumulate gradients into the grad arena
+    /// (beta=1.0 — zeroing is the caller's responsibility).
+    fn eager_backward(&mut self) -> Result<(), String> {
+        let exec = M3Exec {
+            ctx: &self.ctx,
+            kernels: &self.m3k,
+            dims: &self.dims,
+        };
         gpu_backward_mamba3_backbone(
             &exec,
             &mut self.d_temporal,
@@ -1098,7 +1369,11 @@ impl Mamba3TrainerF32 {
             &self.weights,
             &self.grads,
             &mut self.scratch,
-        )?;
+        )
+    }
+
+    /// Eager optimizer tail: AdamW over the grad arena.
+    fn eager_optimize(&mut self) -> Result<(), String> {
         step_m3_capturable(
             &self.ctx,
             &self.m3k.adamw_step_f32_capturable,
@@ -1106,8 +1381,129 @@ impl Mamba3TrainerF32 {
             self.bias.ptr(),
             &mut self.weights,
             &self.grads,
-        )?;
+        )
+    }
+
+    fn step_eager(&mut self) -> Result<(), String> {
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_forward()?;
+        self.eager_backward()?;
+        self.eager_optimize()
+    }
+
+    /// Split forward (see [`Mamba3Trainer::forward`]).
+    pub(crate) fn forward_split(
+        &mut self,
+        input: &[f32],
+        temporal_out: &mut [f32],
+    ) -> Result<(), String> {
+        assert_eq!(
+            input.len(),
+            self.mamba_input.len(),
+            "input shape mismatch: expected batch*seq_len*input_dim={}, got {}",
+            self.mamba_input.len(),
+            input.len(),
+        );
+        assert_eq!(
+            temporal_out.len(),
+            self.temporal.len(),
+            "temporal_out shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.temporal.len(),
+            temporal_out.len(),
+        );
+        self.mamba_input.upload(&self.ctx.stream, input)?;
+        self.eager_forward()?;
+        self.ctx
+            .stream
+            .synchronize()
+            .map_err(|e| format!("forward_split sync: {e:?}"))?;
+        self.temporal.download(&self.ctx.stream, temporal_out)?;
+        self.split_forward_pending = true;
         Ok(())
+    }
+
+    /// Split backward + optimizer (see [`Mamba3Trainer::backward_step`]).
+    pub(crate) fn backward_split(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        if !self.split_forward_pending {
+            return Err(
+                "backward_step() without a pending forward() — the saved activations \
+                 are stale or missing; call forward() first"
+                    .into(),
+            );
+        }
+        if opts.clip_max_norm.is_some() && opts.accumulate_only {
+            return Err(
+                "clip_max_norm + accumulate_only is unsupported: the global norm is only \
+                 defined over the COMPLETE accumulated gradient — request the clip on the \
+                 final (applying) backward_step"
+                    .into(),
+            );
+        }
+        assert_eq!(
+            d_temporal.len(),
+            self.d_temporal.len(),
+            "d_temporal shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.d_temporal.len(),
+            d_temporal.len(),
+        );
+        self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
+        if !self.grads_dirty {
+            self.grads.zero(&self.ctx.stream)?;
+        }
+        self.eager_backward()?;
+        self.split_forward_pending = false;
+
+        if opts.accumulate_only {
+            self.grads_dirty = true;
+            Ok(BackwardMetrics {
+                step: self.adam.step,
+                optimizer_stepped: false,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        } else {
+            let grad_norm = match opts.clip_max_norm {
+                Some(c) => Some(self.apply_clip(c)?),
+                None => None,
+            };
+            let (step, bc1, bc2) = self.adam.advance();
+            self.bias.write(&self.ctx.stream, bc1, bc2)?;
+            self.eager_optimize()?;
+            self.grads_dirty = false;
+            Ok(BackwardMetrics {
+                step,
+                optimizer_stepped: true,
+                grad_norm,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        }
+    }
+
+    /// Compute the deterministic global grad norm, apply the clip
+    /// coefficient when needed, and return the PRE-clip norm.
+    fn apply_clip(&mut self, max_norm: f32) -> Result<f32, String> {
+        let norm = global_grad_norm(
+            &self.ctx,
+            &self.grads.flat,
+            &mut self.clip_partials,
+            &mut self.clip_partials_host,
+        )?;
+        if !norm.is_finite() {
+            return Err(format!(
+                "clip_max_norm: non-finite global grad norm ({norm})"
+            ));
+        }
+        let coef = max_norm as f64 / (norm + 1e-6);
+        if coef < 1.0 {
+            scale_grads(&self.ctx, &mut self.grads.flat, coef as f32)?;
+        }
+        Ok(norm as f32)
     }
 
     pub fn snapshot_master(&self) -> Result<Mamba3Weights, String> {

--- a/src/mamba3_siso/gpu/trainer.rs
+++ b/src/mamba3_siso/gpu/trainer.rs
@@ -144,6 +144,49 @@ impl Mamba3Trainer {
         }
     }
 
+    /// Set the AdamW learning rate for subsequent EAGER steps. Errs while a
+    /// captured graph exists — the lr is baked by value into the captured
+    /// AdamW kernel; a field write would silently not apply under replay.
+    /// Mirrors `MambaTrainer::set_lr`.
+    pub fn set_lr(&mut self, lr: f32) -> Result<(), String> {
+        if !lr.is_finite() || lr <= 0.0 {
+            return Err(format!("set_lr: invalid learning rate {lr}"));
+        }
+        if self.has_graph() {
+            return Err(
+                "set_lr under a captured graph: the lr is baked by value into the \
+                 captured AdamW kernel and a field write would silently not apply — \
+                 drop_graph() first, then set_lr, then re-capture"
+                    .into(),
+            );
+        }
+        match &mut self.inner {
+            Trainer3Inner::F32(t) => t.adam.lr = lr,
+            Trainer3Inner::Mixed(t) => t.adam.lr = lr,
+        }
+        Ok(())
+    }
+
+    /// Current AdamW learning rate.
+    pub fn lr(&self) -> f32 {
+        match &self.inner {
+            Trainer3Inner::F32(t) => t.adam.lr,
+            Trainer3Inner::Mixed(t) => t.adam.lr,
+        }
+    }
+
+    /// Drop any captured step graph so `drop_graph -> set_lr ->
+    /// capture_graph` is expressible. Mirrors `MambaTrainer::drop_graph`.
+    pub fn drop_graph(&mut self) {
+        match &mut self.inner {
+            Trainer3Inner::F32(t) => t.graph = None,
+            Trainer3Inner::Mixed(t) => {
+                t.graph = None;
+                t.graph_f16 = None;
+            }
+        }
+    }
+
     /// Reset the recurrent SSM, K, V, and angle states to zero.
     pub fn reset_state(&mut self) -> Result<(), String> {
         match &mut self.inner {

--- a/src/mamba3_siso/mod.rs
+++ b/src/mamba3_siso/mod.rs
@@ -28,6 +28,10 @@ pub use cpu::inference::{Mamba3StepScratch, mamba3_layer_step, mamba3_step, mamb
 pub use cpu::parallel::{
     invalidate_mamba3_scratch, parallel_mamba3_backward, parallel_mamba3_forward,
 };
+pub use cpu::prefill::{
+    Mamba3PrefillScratch, forward_mamba3_backbone_prefill, forward_mamba3_backbone_prefill_mode,
+    prefill3_batch,
+};
 pub use cpu::scratch::Mamba3Scratch;
 pub use cpu::weights::{TrainMamba3LayerWeights, TrainMamba3Weights};
 pub use state::{Mamba3LayerState, Mamba3State};

--- a/src/mamba_ssm/cpu/mod.rs
+++ b/src/mamba_ssm/cpu/mod.rs
@@ -11,6 +11,7 @@ pub mod flat;
 pub mod forward;
 pub mod inference;
 pub mod parallel;
+pub mod prefill;
 pub mod scratch;
 pub mod target;
 pub mod weights;

--- a/src/mamba_ssm/cpu/prefill.rs
+++ b/src/mamba_ssm/cpu/prefill.rs
@@ -1,0 +1,721 @@
+//! Full-sequence CPU inference forward ("prefill").
+//!
+//! The per-step inference path costs one matvec pipeline per token — a full
+//! page/prompt of T tokens pays T dispatches and re-streams every weight
+//! matrix T times. This module runs the SAME math as the training forward's
+//! batched-SGEMM pipeline (`train::forward::forward_mamba_backbone_batched`)
+//! WITHOUT saving the activation tape, on inference types (`MambaWeights` —
+//! the precomputed `a_neg` is the SSM decay source — and `MambaState`,
+//! carried in AND out so `forward_step` continues seamlessly:
+//! prefill-then-decode).
+//!
+//! Hard math constraints (the per-step `target.rs` template is wrong on
+//! both): `norm_f` is applied at EVERY position — consumers pool over all
+//! positions — and the RMSNorm epsilon comes from `dims.rms_norm_eps`,
+//! never a hardcoded constant.
+//!
+//! Layout doctrine (measured, not aesthetic): the per-channel phases
+//! (conv1d, SSM recurrence) touch ONLY channel-major `[di * T]` buffers —
+//! one row-major access inside a per-channel loop is a multi-KB-stride
+//! cache-miss per element and dominated the whole prefill at real T before
+//! the re-layout. Cache-blocked transposes bridge to the row-major GEMM
+//! I/O; gating runs as a sequential row-major pass AFTER the transpose
+//! (the same two-operand product, so it stays bit-identical to the fused
+//! form). In [`PrefillMode::Parallel`] EVERY phase parallelizes — GEMMs via
+//! [`sgemm_forward_par`], per-channel phases via `par_chunks_mut` over
+//! channels, elementwise/transposes via `par_chunks_mut` over rows/tiles —
+//! with no cross-task reductions, so Parallel is bit-equal to Single by
+//! construction (the parallel-invariance test pins it), and both are
+//! bit-equal to the training forward (the anchor test pins that).
+//!
+//! Conv-state convention adaptation: the inference `MambaLayerState` stores
+//! `d_conv - 1` history entries per channel; the training-style register is
+//! `d_conv` wide. Prefill widens on entry (history in slots `1..d_conv`;
+//! slot 0 is dead — the first shift discards it) and writes the last
+//! `d_conv - 1` register entries back on exit.
+
+use rayon::prelude::*;
+
+use crate::ops::blas::{sgemm_forward, sgemm_forward_par};
+use crate::ops::dims::MambaDims;
+use crate::ops::fast_math::{fast_exp_inplace, fast_exp_scalar};
+use crate::state::MambaState;
+use crate::weights::{MambaLayerWeights, MambaWeights};
+
+/// Maximum `d_state` the stack-allocated per-channel `da` buffer covers.
+/// Matches the GPU dispatch ceiling for the sequential kernels.
+const MAX_D_STATE: usize = 64;
+
+/// Row-major forward GEMM `(out, x, w, bias, m, k, n)` — the shared
+/// signature of [`sgemm_forward`] and [`sgemm_forward_par`].
+type GemmFn = fn(&mut [f32], &[f32], &[f32], Option<&[f32]>, usize, usize, usize);
+
+/// Transpose tile edge: 64 x 64 f32 = two 16 KB panels — both stay
+/// L1-resident, so the strided side costs one miss per LINE instead of one
+/// miss per ELEMENT (the naive column walk was a measured prefill
+/// bottleneck at real T).
+const TRANSPOSE_TILE: usize = 64;
+
+/// GEMM / phase execution mode for the prefill.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrefillMode {
+    /// Serial everything — the deterministic single-thread reference.
+    Single,
+    /// Rayon-parallel GEMMs + channel-parallel conv/SSM + row-parallel
+    /// elementwise phases and transposes — the single-page serving latency
+    /// mode. Bit-equal to `Single` (no cross-task reductions; tile-local
+    /// GEMM accumulation).
+    Parallel,
+}
+
+/// Run a per-row transform over `dst` rows zipped with `src` rows,
+/// serial or rayon-parallel per `mode`. Rows are disjoint, so both
+/// dispatches perform the identical per-element arithmetic.
+fn zip_rows<F>(mode: PrefillMode, dst: (&mut [f32], usize), src: (&[f32], usize), f: F)
+where
+    F: Fn(&mut [f32], &[f32]) + Sync + Send,
+{
+    let (dst, dst_w) = dst;
+    let (src, src_w) = src;
+    match mode {
+        PrefillMode::Single => dst
+            .chunks_mut(dst_w)
+            .zip(src.chunks(src_w))
+            .for_each(|(d, s)| f(d, s)),
+        PrefillMode::Parallel => dst
+            .par_chunks_mut(dst_w)
+            .zip(src.par_chunks(src_w))
+            .for_each(|(d, s)| f(d, s)),
+    }
+}
+
+/// Run a per-row transform over `buf` rows, serial or rayon-parallel.
+fn for_rows<F>(mode: PrefillMode, buf: &mut [f32], row_w: usize, f: F)
+where
+    F: Fn(&mut [f32]) + Sync + Send,
+{
+    match mode {
+        PrefillMode::Single => buf.chunks_mut(row_w).for_each(f),
+        PrefillMode::Parallel => buf.par_chunks_mut(row_w).for_each(f),
+    }
+}
+
+/// Reusable prefill scratch. `ensure` re-allocates only when the dims
+/// fingerprint changes — zero allocation on the serving hot path once
+/// warmed (keyed on the FULL dims, the `parallel.rs` OOB lesson).
+pub struct PrefillScratch {
+    fingerprint: (usize, usize, usize, usize, usize, usize, usize),
+    post_norm: Vec<f32>,
+    proj: Vec<f32>,
+    gate_silu: Vec<f32>,
+    /// Channel-major conv/SSM I/O `[di * T]` (see the module doctrine).
+    x_cm: Vec<f32>,
+    u_cm: Vec<f32>,
+    delta_cm: Vec<f32>,
+    y_cm: Vec<f32>,
+    /// Row-major GEMM I/O `[T * di]`.
+    u_rm: Vec<f32>,
+    delta_rm: Vec<f32>,
+    y_rm: Vec<f32>,
+    xdbl: Vec<f32>,
+    dt_in: Vec<f32>,
+    out: Vec<f32>,
+    /// Training-convention conv registers, channel-major `[di * dc]`.
+    conv_reg: Vec<f32>,
+}
+
+fn fingerprint(dims: &MambaDims) -> (usize, usize, usize, usize, usize, usize, usize) {
+    (
+        dims.seq_len,
+        dims.d_model,
+        dims.d_inner,
+        dims.d_state,
+        dims.d_conv,
+        dims.dt_rank,
+        dims.mamba_input_dim,
+    )
+}
+
+impl PrefillScratch {
+    /// Allocate scratch sized for `dims`.
+    pub fn new(dims: &MambaDims) -> Self {
+        let t = dims.seq_len;
+        let di = dims.d_inner;
+        Self {
+            fingerprint: fingerprint(dims),
+            post_norm: vec![0.0; t * dims.d_model],
+            proj: vec![0.0; t * 2 * di],
+            gate_silu: vec![0.0; t * di],
+            x_cm: vec![0.0; di * t],
+            u_cm: vec![0.0; di * t],
+            delta_cm: vec![0.0; di * t],
+            y_cm: vec![0.0; di * t],
+            u_rm: vec![0.0; t * di],
+            delta_rm: vec![0.0; t * di],
+            y_rm: vec![0.0; t * di],
+            xdbl: vec![0.0; t * dims.xdbl_dim],
+            dt_in: vec![0.0; t * dims.dt_rank],
+            out: vec![0.0; t * dims.d_model],
+            conv_reg: vec![0.0; di * dims.d_conv],
+        }
+    }
+
+    /// Re-size for a different dims fingerprint (no-op when unchanged).
+    pub fn ensure(&mut self, dims: &MambaDims) {
+        if fingerprint(dims) != self.fingerprint {
+            *self = Self::new(dims);
+        }
+    }
+}
+
+/// Conv1d + fused SiLU for ONE channel over the full sequence.
+/// `x_col`/`u_col`/`reg` are this channel's contiguous slices — every hot
+/// access is sequential. The first `d_conv - 1` positions run the shift
+/// register (they tap carried history); the bulk runs tap-outer vectorized
+/// FMA passes whose per-element accumulation chain
+/// (`bias, +w0*x, +w1*x, ...`) is IDENTICAL to the register form, so the
+/// split is bit-exact.
+fn conv_channel(
+    d: usize,
+    u_col: &mut [f32],
+    reg: &mut [f32],
+    x_col: &[f32],
+    lw: &MambaLayerWeights,
+    dims: &MambaDims,
+) {
+    let dc = dims.d_conv;
+    let hist = dc - 1;
+    let t_len = u_col.len();
+    let w_base = d * dc;
+    let bias = lw.conv1d_bias[d];
+    let head = hist.min(t_len);
+
+    // Head: shift-register form over the carried history.
+    for (u_td, &xb) in u_col[..head].iter_mut().zip(&x_col[..head]) {
+        for k in 0..dc - 1 {
+            reg[k] = reg[k + 1];
+        }
+        reg[dc - 1] = xb;
+        let mut val = bias;
+        for (r, w_k) in reg.iter().zip(&lw.conv1d_weight[w_base..w_base + dc]) {
+            val += r * w_k;
+        }
+        *u_td = val;
+    }
+
+    // Bulk: tap-outer vector FMA (taps k of position t read x[t - hist + k]).
+    if t_len > hist {
+        let bulk = &mut u_col[hist..];
+        bulk.fill(bias);
+        for (k, &w_k) in lw.conv1d_weight[w_base..w_base + dc].iter().enumerate() {
+            for (u, &xv) in bulk.iter_mut().zip(&x_col[k..k + t_len - hist]) {
+                *u += xv * w_k;
+            }
+        }
+        // Refresh the register for state writeback (slot 0 is dead).
+        for (r, &xv) in reg[1..dc].iter_mut().zip(&x_col[t_len - hist..]) {
+            *r = xv;
+        }
+    }
+
+    // SiLU sweep (same per-element expression as the fused form).
+    for u in u_col.iter_mut() {
+        *u = *u / (1.0 + fast_exp_scalar(-*u));
+    }
+}
+
+/// Channels per SSM task. The per-(t, d) output `y` is a serial chain of
+/// `d_state` dependent FMAs (~4-cycle latency each) — the measured prefill
+/// hot spot. Interleaving `SSM_BLOCK` independent channels in the state
+/// loop runs that many chains concurrently (latency hiding) and amortizes
+/// the shared B/C row loads, while each channel's own accumulation ORDER is
+/// untouched — so the block form stays bit-exact vs the one-channel form
+/// and the training forward.
+const SSM_BLOCK: usize = 8;
+
+/// SSM recurrence for a BLOCK of up to [`SSM_BLOCK`] channels over the full
+/// sequence (ungated — the gate multiply happens in a sequential row-major
+/// pass afterwards). `y_cols`/`ssm` are the block's channel-major slices
+/// (`nch` inferred from their length); `xdbl` streams row-sequentially (B/C
+/// are shared per-position vectors, loaded once per block).
+fn ssm_channels(
+    block: usize,
+    y_cols: &mut [f32],
+    ssm: &mut [f32],
+    io: (&[f32], &[f32], &[f32]),
+    lw: &MambaLayerWeights,
+    dims: &MambaDims,
+) {
+    let (u_cols, delta_cols, xdbl) = io;
+    let ds = dims.d_state;
+    let dr = dims.dt_rank;
+    let xd = dims.xdbl_dim;
+    let t_len = dims.seq_len;
+    let d0 = block * SSM_BLOCK;
+    let nch = y_cols.len() / t_len;
+    let b_offset = dr;
+    let c_offset = dr + ds;
+
+    // Lane-major locals: index [n * SSM_BLOCK + c] with the CONSTANT block
+    // stride — the inner state loop compiles to straight 4-wide SIMD with
+    // one contiguous load per operand. Lanes past `nch` (a tail block when
+    // d_inner % SSM_BLOCK != 0) compute garbage that never mixes into valid
+    // lanes (per-lane arithmetic only) and is never written back (`ssm` and
+    // `y_cols` hold exactly `nch` channels).
+    let mut da = [0.0f32; MAX_D_STATE * SSM_BLOCK];
+    let mut hloc = [0.0f32; MAX_D_STATE * SSM_BLOCK];
+    let mut du = [0.0f32; SSM_BLOCK];
+    let mut y_acc = [0.0f32; SSM_BLOCK];
+
+    // Load the block's ssm state into lane-major.
+    for (c, ssm_ch) in ssm.chunks(ds).enumerate() {
+        for (n, &s) in ssm_ch.iter().enumerate() {
+            hloc[n * SSM_BLOCK + c] = s;
+        }
+    }
+
+    for t in 0..t_len {
+        let xdbl_row = t * xd;
+        for (c, du_c) in du[..nch].iter_mut().enumerate() {
+            let delta_d = delta_cols[c * t_len + t];
+            *du_c = delta_d * u_cols[c * t_len + t];
+            let a_base = (d0 + c) * ds;
+            for (n, a_n) in lw.a_neg[a_base..a_base + ds].iter().enumerate() {
+                da[n * SSM_BLOCK + c] = delta_d * a_n;
+            }
+        }
+        fast_exp_inplace(&mut da[..ds * SSM_BLOCK]);
+        y_acc.fill(0.0);
+        for (n, (da_l, h_l)) in da
+            .chunks_exact(SSM_BLOCK)
+            .zip(hloc.chunks_exact_mut(SSM_BLOCK))
+            .enumerate()
+            .take(ds)
+        {
+            let b_n = xdbl[xdbl_row + b_offset + n];
+            let c_n = xdbl[xdbl_row + c_offset + n];
+            for c in 0..SSM_BLOCK {
+                let h = da_l[c] * h_l[c] + du[c] * b_n;
+                h_l[c] = h;
+                y_acc[c] += h * c_n;
+            }
+        }
+        for (c, &y_c) in y_acc[..nch].iter().enumerate() {
+            let u_td = u_cols[c * t_len + t];
+            y_cols[c * t_len + t] = y_c + lw.d_param[d0 + c] * u_td;
+        }
+    }
+
+    // Write the block's ssm state back from lane-major.
+    for (c, ssm_ch) in ssm.chunks_mut(ds).enumerate() {
+        for (n, s) in ssm_ch.iter_mut().enumerate() {
+            *s = hloc[n * SSM_BLOCK + c];
+        }
+    }
+}
+
+/// `dst[t * di + d] = src[d * t_len + t]` — channel-major → row-major,
+/// cache-blocked; parallel over row-tiles in `Parallel` (disjoint dst rows).
+fn transpose_cm_to_rm(dst: &mut [f32], src: &[f32], di: usize, t_len: usize, mode: PrefillMode) {
+    let row_block = TRANSPOSE_TILE * di;
+    let work = |(tb, dst_tile): (usize, &mut [f32])| {
+        let t0 = tb * TRANSPOSE_TILE;
+        let rows = dst_tile.len() / di;
+        for d0 in (0..di).step_by(TRANSPOSE_TILE) {
+            let d1 = (d0 + TRANSPOSE_TILE).min(di);
+            for d in d0..d1 {
+                let col = &src[d * t_len + t0..d * t_len + t0 + rows];
+                for (r, &v) in col.iter().enumerate() {
+                    dst_tile[r * di + d] = v;
+                }
+            }
+        }
+    };
+    match mode {
+        PrefillMode::Single => dst[..t_len * di]
+            .chunks_mut(row_block)
+            .enumerate()
+            .for_each(work),
+        PrefillMode::Parallel => dst[..t_len * di]
+            .par_chunks_mut(row_block)
+            .enumerate()
+            .for_each(work),
+    }
+}
+
+/// `dst[d * t_len + t] = src[t * src_stride + src_off + d]` — strided
+/// row-major → channel-major, cache-blocked; parallel over channel-tiles in
+/// `Parallel` (disjoint dst columns). `src_stride`/`src_off` let the x
+/// branch be pulled straight out of the interleaved `[T, 2*di]` in_proj
+/// output without a compaction pass.
+fn transpose_rows_to_cm(
+    dst: &mut [f32],
+    src: &[f32],
+    di: usize,
+    t_len: usize,
+    stride: (usize, usize),
+    mode: PrefillMode,
+) {
+    let (src_stride, src_off) = stride;
+    let col_block = TRANSPOSE_TILE * t_len;
+    let work = |(db, dst_tile): (usize, &mut [f32])| {
+        let d0 = db * TRANSPOSE_TILE;
+        for t0 in (0..t_len).step_by(TRANSPOSE_TILE) {
+            let t1 = (t0 + TRANSPOSE_TILE).min(t_len);
+            for (c, col) in dst_tile.chunks_mut(t_len).enumerate() {
+                for (i, v) in col[t0..t1].iter_mut().enumerate() {
+                    *v = src[(t0 + i) * src_stride + src_off + d0 + c];
+                }
+            }
+        }
+    };
+    match mode {
+        PrefillMode::Single => dst[..di * t_len]
+            .chunks_mut(col_block)
+            .enumerate()
+            .for_each(work),
+        PrefillMode::Parallel => dst[..di * t_len]
+            .par_chunks_mut(col_block)
+            .enumerate()
+            .for_each(work),
+    }
+}
+
+/// Full-sequence CPU inference forward of the M1 backbone (serial mode).
+///
+/// - `temporal_out`: `[T * d_model]` — the POST-norm_f output at EVERY
+///   position (consumers pool over all of them).
+/// - `mamba_input_flat`: `[T * mamba_input_dim]`.
+/// - `w`: inference weights. `a_neg` is the SSM decay source — callers that
+///   mutate `a_log` must refresh `a_neg` before prefilling.
+/// - `state`: recurrent conv/SSM state, carried in AND out
+///   (prefill-then-decode into [`crate::inference`]'s step path).
+/// - `scratch`: caller-owned; `ensure`d to `dims` internally.
+pub fn forward_mamba_backbone_prefill(
+    temporal_out: &mut [f32],
+    mamba_input_flat: &[f32],
+    w: &MambaWeights,
+    state: &mut MambaState,
+    scratch: &mut PrefillScratch,
+    dims: &MambaDims,
+) {
+    forward_mamba_backbone_prefill_mode(
+        temporal_out,
+        mamba_input_flat,
+        w,
+        state,
+        scratch,
+        dims,
+        PrefillMode::Single,
+    );
+}
+
+/// [`forward_mamba_backbone_prefill`] with an explicit execution mode.
+pub fn forward_mamba_backbone_prefill_mode(
+    temporal_out: &mut [f32],
+    mamba_input_flat: &[f32],
+    w: &MambaWeights,
+    state: &mut MambaState,
+    scratch: &mut PrefillScratch,
+    dims: &MambaDims,
+    mode: PrefillMode,
+) {
+    let dm = dims.d_model;
+    let di = dims.d_inner;
+    let ds = dims.d_state;
+    let dc = dims.d_conv;
+    let dr = dims.dt_rank;
+    let xd = dims.xdbl_dim;
+    let mid = dims.mamba_input_dim;
+    let t_len = dims.seq_len;
+    let hist = dc - 1;
+    let eps = dims.rms_norm_eps;
+
+    assert!(ds <= MAX_D_STATE, "d_state > {MAX_D_STATE} unsupported");
+    assert_eq!(temporal_out.len(), t_len * dm, "temporal_out shape");
+    assert_eq!(mamba_input_flat.len(), t_len * mid, "input shape");
+    assert_eq!(state.layers.len(), dims.n_layers, "state layer count");
+    scratch.ensure(dims);
+
+    let gemm: GemmFn = match mode {
+        PrefillMode::Single => sgemm_forward,
+        PrefillMode::Parallel => sgemm_forward_par,
+    };
+
+    // Input projection (identity D2D for HF checkpoints with empty proj).
+    if w.input_proj_w.is_empty() {
+        debug_assert_eq!(mid, dm, "identity input_proj requires input_dim == d_model");
+        temporal_out[..t_len * dm].copy_from_slice(&mamba_input_flat[..t_len * dm]);
+    } else {
+        gemm(
+            temporal_out,
+            mamba_input_flat,
+            &w.input_proj_w,
+            Some(&w.input_proj_b),
+            t_len,
+            mid,
+            dm,
+        );
+    }
+
+    for (layer_idx, lw) in w.layers.iter().enumerate() {
+        let lstate = &mut state.layers[layer_idx];
+
+        // F1: RMSNorm at every position (dims eps — never hardcoded).
+        // `temporal_out` doubles as the residual: it is only read here and
+        // updated in-place at F6, so no residual copy is needed.
+        zip_rows(
+            mode,
+            (&mut scratch.post_norm[..t_len * dm], dm),
+            (&temporal_out[..t_len * dm], dm),
+            |dst, src| {
+                let mut sum_sq = 0.0_f32;
+                for &v in src {
+                    sum_sq += v * v;
+                }
+                let inv_rms = 1.0 / (sum_sq / dm as f32 + eps).sqrt();
+                for ((y, &s), nw) in dst.iter_mut().zip(src).zip(&lw.norm_weight[..dm]) {
+                    *y = s * inv_rms * nw;
+                }
+            },
+        );
+
+        // F2: in_proj GEMM.
+        gemm(
+            &mut scratch.proj,
+            &scratch.post_norm,
+            &lw.in_proj_w,
+            None,
+            t_len,
+            dm,
+            2 * di,
+        );
+
+        // F3: gate SiLU (the x branch stays in `proj` for the conv phase).
+        zip_rows(
+            mode,
+            (&mut scratch.gate_silu[..t_len * di], di),
+            (&scratch.proj[..t_len * 2 * di], 2 * di),
+            |gs, proj_row| {
+                for (g_out, &g) in gs.iter_mut().zip(&proj_row[di..2 * di]) {
+                    *g_out = g * (1.0 / (1.0 + fast_exp_scalar(-g)));
+                }
+            },
+        );
+
+        // Pull the x branch out of the interleaved in_proj output into
+        // channel-major (blocked transpose — the per-channel conv loop must
+        // never touch the row-major `proj`).
+        transpose_rows_to_cm(
+            &mut scratch.x_cm,
+            &scratch.proj,
+            di,
+            t_len,
+            (2 * di, 0),
+            mode,
+        );
+
+        // Widen the inference conv history into the training-style register.
+        for d in 0..di {
+            scratch.conv_reg[d * dc] = 0.0;
+            scratch.conv_reg[d * dc + 1..d * dc + dc]
+                .copy_from_slice(&lstate.conv_state[d * hist..(d + 1) * hist]);
+        }
+
+        // F4a: conv1d + SiLU, per channel (contiguous columns only).
+        {
+            let x_cm = &scratch.x_cm[..];
+            match mode {
+                PrefillMode::Single => {
+                    for (d, (u_col, reg)) in scratch
+                        .u_cm
+                        .chunks_mut(t_len)
+                        .zip(scratch.conv_reg.chunks_mut(dc))
+                        .enumerate()
+                    {
+                        conv_channel(d, u_col, reg, &x_cm[d * t_len..(d + 1) * t_len], lw, dims);
+                    }
+                }
+                PrefillMode::Parallel => {
+                    scratch
+                        .u_cm
+                        .par_chunks_mut(t_len)
+                        .zip(scratch.conv_reg.par_chunks_mut(dc))
+                        .enumerate()
+                        .for_each(|(d, (u_col, reg))| {
+                            conv_channel(
+                                d,
+                                u_col,
+                                reg,
+                                &x_cm[d * t_len..(d + 1) * t_len],
+                                lw,
+                                dims,
+                            );
+                        });
+                }
+            }
+        }
+        transpose_cm_to_rm(&mut scratch.u_rm, &scratch.u_cm, di, t_len, mode);
+
+        // F4b: x_proj GEMM + dt gather.
+        gemm(
+            &mut scratch.xdbl,
+            &scratch.u_rm,
+            &lw.x_proj_w,
+            None,
+            t_len,
+            di,
+            xd,
+        );
+        zip_rows(
+            mode,
+            (&mut scratch.dt_in[..t_len * dr], dr),
+            (&scratch.xdbl[..t_len * xd], xd),
+            |dst, src| dst.copy_from_slice(&src[..dr]),
+        );
+
+        // F4c: dt_proj GEMM + softplus (threshold 20, same as training).
+        gemm(
+            &mut scratch.delta_rm,
+            &scratch.dt_in,
+            &lw.dt_proj_w,
+            Some(&lw.dt_proj_b),
+            t_len,
+            dr,
+            di,
+        );
+        for_rows(mode, &mut scratch.delta_rm[..t_len * di], di, |row| {
+            for v in row {
+                if *v <= 20.0 {
+                    *v = fast_exp_scalar(*v).ln_1p();
+                }
+            }
+        });
+        transpose_rows_to_cm(
+            &mut scratch.delta_cm,
+            &scratch.delta_rm,
+            di,
+            t_len,
+            (di, 0),
+            mode,
+        );
+
+        // F4d: SSM recurrence, per channel block (ungated).
+        {
+            let u_cm = &scratch.u_cm[..];
+            let delta_cm = &scratch.delta_cm[..];
+            let xdbl = &scratch.xdbl[..];
+            let blk_t = SSM_BLOCK * t_len;
+            match mode {
+                PrefillMode::Single => {
+                    for (blk, (y_cols, ssm)) in scratch
+                        .y_cm
+                        .chunks_mut(blk_t)
+                        .zip(lstate.ssm_state.chunks_mut(SSM_BLOCK * ds))
+                        .enumerate()
+                    {
+                        let span = blk * blk_t..blk * blk_t + y_cols.len();
+                        let io = (&u_cm[span.clone()], &delta_cm[span], xdbl);
+                        ssm_channels(blk, y_cols, ssm, io, lw, dims);
+                    }
+                }
+                PrefillMode::Parallel => {
+                    scratch
+                        .y_cm
+                        .par_chunks_mut(blk_t)
+                        .zip(lstate.ssm_state.par_chunks_mut(SSM_BLOCK * ds))
+                        .enumerate()
+                        .for_each(|(blk, (y_cols, ssm))| {
+                            let span = blk * blk_t..blk * blk_t + y_cols.len();
+                            let io = (&u_cm[span.clone()], &delta_cm[span], xdbl);
+                            ssm_channels(blk, y_cols, ssm, io, lw, dims);
+                        });
+                }
+            }
+        }
+        transpose_cm_to_rm(&mut scratch.y_rm, &scratch.y_cm, di, t_len, mode);
+
+        // F4e: gating in row-major (same two-operand product as the fused
+        // per-channel version — bit-identical, cache-friendly).
+        zip_rows(
+            mode,
+            (&mut scratch.y_rm[..t_len * di], di),
+            (&scratch.gate_silu[..t_len * di], di),
+            |y_row, g_row| {
+                for (y, &g) in y_row.iter_mut().zip(g_row) {
+                    *y *= g;
+                }
+            },
+        );
+
+        // Write the conv history back (last dc-1 register entries).
+        for d in 0..di {
+            lstate.conv_state[d * hist..(d + 1) * hist]
+                .copy_from_slice(&scratch.conv_reg[d * dc + 1..d * dc + dc]);
+        }
+
+        // F5/F6: out_proj GEMM + in-place residual add.
+        gemm(
+            &mut scratch.out,
+            &scratch.y_rm,
+            &lw.out_proj_w,
+            None,
+            t_len,
+            di,
+            dm,
+        );
+        zip_rows(
+            mode,
+            (&mut temporal_out[..t_len * dm], dm),
+            (&scratch.out[..t_len * dm], dm),
+            |y_row, o_row| {
+                for (y, &o) in y_row.iter_mut().zip(o_row) {
+                    *y += o;
+                }
+            },
+        );
+    }
+
+    // norm_f at EVERY position, dims eps.
+    for_rows(mode, &mut temporal_out[..t_len * dm], dm, |row| {
+        let mut sum_sq = 0.0_f32;
+        for &v in row.iter() {
+            sum_sq += v * v;
+        }
+        let inv_rms = 1.0 / (sum_sq / dm as f32 + eps).sqrt();
+        for (y, nw) in row.iter_mut().zip(&w.norm_f_weight[..dm]) {
+            *y *= inv_rms * nw;
+        }
+    });
+}
+
+/// Prefill a batch of independent sequences in parallel (one rayon task per
+/// sample; each task runs [`PrefillMode::Single`] internally — batch-level
+/// parallelism already saturates the cores). Scratches are per-sample and
+/// caller-owned so the serving layer controls its memory bound.
+pub fn prefill_batch(
+    outputs: &mut [f32],
+    inputs: &[f32],
+    w: &MambaWeights,
+    states: &mut [MambaState],
+    scratches: &mut [PrefillScratch],
+    dims: &MambaDims,
+) {
+    let t_len = dims.seq_len;
+    let dm = dims.d_model;
+    let mid = dims.mamba_input_dim;
+    let b = states.len();
+    assert_eq!(scratches.len(), b, "one scratch per sample");
+    assert_eq!(outputs.len(), b * t_len * dm, "outputs shape");
+    assert_eq!(inputs.len(), b * t_len * mid, "inputs shape");
+
+    outputs
+        .par_chunks_mut(t_len * dm)
+        .zip(states.par_iter_mut())
+        .zip(scratches.par_iter_mut())
+        .enumerate()
+        .for_each(|(i, ((out, state), scratch))| {
+            let inp = &inputs[i * t_len * mid..(i + 1) * t_len * mid];
+            forward_mamba_backbone_prefill(out, inp, w, state, scratch, dims);
+        });
+}

--- a/src/mamba_ssm/cpu/prefill.rs
+++ b/src/mamba_ssm/cpu/prefill.rs
@@ -71,7 +71,7 @@ pub enum PrefillMode {
 /// Run a per-row transform over `dst` rows zipped with `src` rows,
 /// serial or rayon-parallel per `mode`. Rows are disjoint, so both
 /// dispatches perform the identical per-element arithmetic.
-fn zip_rows<F>(mode: PrefillMode, dst: (&mut [f32], usize), src: (&[f32], usize), f: F)
+pub(crate) fn zip_rows<F>(mode: PrefillMode, dst: (&mut [f32], usize), src: (&[f32], usize), f: F)
 where
     F: Fn(&mut [f32], &[f32]) + Sync + Send,
 {
@@ -90,7 +90,7 @@ where
 }
 
 /// Run a per-row transform over `buf` rows, serial or rayon-parallel.
-fn for_rows<F>(mode: PrefillMode, buf: &mut [f32], row_w: usize, f: F)
+pub(crate) fn for_rows<F>(mode: PrefillMode, buf: &mut [f32], row_w: usize, f: F)
 where
     F: Fn(&mut [f32]) + Sync + Send,
 {
@@ -316,7 +316,13 @@ fn ssm_channels(
 
 /// `dst[t * di + d] = src[d * t_len + t]` — channel-major → row-major,
 /// cache-blocked; parallel over row-tiles in `Parallel` (disjoint dst rows).
-fn transpose_cm_to_rm(dst: &mut [f32], src: &[f32], di: usize, t_len: usize, mode: PrefillMode) {
+pub(crate) fn transpose_cm_to_rm(
+    dst: &mut [f32],
+    src: &[f32],
+    di: usize,
+    t_len: usize,
+    mode: PrefillMode,
+) {
     let row_block = TRANSPOSE_TILE * di;
     let work = |(tb, dst_tile): (usize, &mut [f32])| {
         let t0 = tb * TRANSPOSE_TILE;
@@ -348,7 +354,7 @@ fn transpose_cm_to_rm(dst: &mut [f32], src: &[f32], di: usize, t_len: usize, mod
 /// `Parallel` (disjoint dst columns). `src_stride`/`src_off` let the x
 /// branch be pulled straight out of the interleaved `[T, 2*di]` in_proj
 /// output without a compaction pass.
-fn transpose_rows_to_cm(
+pub(crate) fn transpose_rows_to_cm(
     dst: &mut [f32],
     src: &[f32],
     di: usize,

--- a/src/mamba_ssm/gpu/adamw.rs
+++ b/src/mamba_ssm/gpu/adamw.rs
@@ -466,7 +466,8 @@ pub fn step_m1(
 
     // Build paired iterator in the EXACT layout of `GpuMambaGrads::new`:
     // input_proj_w, input_proj_b, [layers...], norm_f_weight.
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> = Vec::new();
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> =
+        Vec::with_capacity(3 + 10 * weights.layers.len());
     pairs.push((&weights.input_proj_w, &grads.input_proj_w));
     pairs.push((&weights.input_proj_b, &grads.input_proj_b));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {
@@ -501,7 +502,8 @@ pub fn step_m1_capturable(
     // (weight, grad, reference-no-decay?). The no-decay group is the set the
     // reference implementation marks `_no_weight_decay`: a_log, D, dt bias,
     // plus every RMSNorm scale — active only when `adam.reference_no_decay`.
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> = Vec::new();
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> =
+        Vec::with_capacity(3 + 10 * weights.layers.len());
     pairs.push((&weights.input_proj_w, &grads.input_proj_w, false));
     pairs.push((&weights.input_proj_b, &grads.input_proj_b, false));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {
@@ -550,7 +552,8 @@ pub fn step_m3_capturable(
     // every norm scale. M3 has no fixed a_log (A is input-dependent); the
     // B/C biases stay decayed (only the reference-named analogues are
     // exempted). Active only when `adam.reference_no_decay`.
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> = Vec::new();
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> =
+        Vec::with_capacity(3 + 10 * weights.layers.len());
     pairs.push((&weights.input_proj_w, &grads.input_proj_w, false));
     pairs.push((&weights.input_proj_b, &grads.input_proj_b, false));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {
@@ -597,7 +600,8 @@ pub fn step_m3(
     let (_, bc1, bc2) = adam.advance();
     let flat_base = grads.flat.cached_ptr();
 
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> = Vec::new();
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> =
+        Vec::with_capacity(3 + 10 * weights.layers.len());
     pairs.push((&weights.input_proj_w, &grads.input_proj_w));
     pairs.push((&weights.input_proj_b, &grads.input_proj_b));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {

--- a/src/mamba_ssm/gpu/adamw.rs
+++ b/src/mamba_ssm/gpu/adamw.rs
@@ -112,6 +112,16 @@ pub struct GpuAdamW {
     pub beta2: f32,
     pub eps: f32,
     pub weight_decay: f32,
+    /// Reference-faithful no-decay parameter groups. When true, the
+    /// per-tensor step functions ([`step_m1_capturable`] /
+    /// [`step_m3_capturable`]) pass `weight_decay = 0` for the parameters
+    /// the reference implementation marks `_no_weight_decay` — M1: `a_log`,
+    /// `d_param`, `dt_proj_b` and the RMSNorm scales; M3: `dt_bias`,
+    /// `d_param` and every norm scale. Decaying `a_log` pulls all decay
+    /// rates toward A = -1 over long runs. Default `false` preserves the
+    /// historical decay-everything behavior bit-for-bit; costs nothing
+    /// either way (the decay coefficient is a per-launch scalar).
+    pub reference_no_decay: bool,
 }
 
 impl GpuAdamW {
@@ -130,7 +140,16 @@ impl GpuAdamW {
             beta2: 0.999,
             eps: 1e-8,
             weight_decay: 1e-2,
+            reference_no_decay: false,
         })
+    }
+
+    /// Toggle the reference-faithful no-decay parameter groups (see the
+    /// field docs on [`Self::reference_no_decay`]).
+    #[must_use]
+    pub fn with_reference_no_decay(mut self, on: bool) -> Self {
+        self.reference_no_decay = on;
+        self
     }
 
     #[must_use]
@@ -231,6 +250,29 @@ impl GpuAdamW {
         bias_factors_ptr: cudarc::driver::sys::CUdeviceptr,
         len: usize,
     ) -> Result<(), String> {
+        self.step_one_capturable_wd(
+            ctx,
+            adamw_kernel,
+            ptrs,
+            bias_factors_ptr,
+            len,
+            self.weight_decay,
+        )
+    }
+
+    /// [`Self::step_one_capturable`] with an explicit per-tensor weight
+    /// decay — the mechanism behind the reference no-decay groups (the
+    /// decay coefficient is a per-launch scalar, so per-tensor decay costs
+    /// nothing).
+    pub fn step_one_capturable_wd(
+        &self,
+        ctx: &GpuCtx,
+        adamw_kernel: &CudaFunction,
+        ptrs: AdamWParamPtrs,
+        bias_factors_ptr: cudarc::driver::sys::CUdeviceptr,
+        len: usize,
+        weight_decay: f32,
+    ) -> Result<(), String> {
         if len == 0 {
             return Ok(());
         }
@@ -245,7 +287,7 @@ impl GpuAdamW {
         bld.arg(&self.beta1);
         bld.arg(&self.beta2);
         bld.arg(&self.eps);
-        bld.arg(&self.weight_decay);
+        bld.arg(&weight_decay);
         bld.arg(&bias_factors_ptr);
         bld.arg(&n);
         unsafe { bld.launch(cfg) }.map_err(|e| format!("adamw_step_f32_capturable: {e:?}"))?;
@@ -346,44 +388,67 @@ pub fn run_pairs_capturable(
     flat_grad_base: cudarc::driver::sys::CUdeviceptr,
     pairs: &[(&GpuBuffer, &GradSlice)],
 ) -> Result<(), String> {
-    let m_base = adam.m.cached_ptr();
-    let v_base = adam.v.cached_ptr();
-    for (w, g) in pairs {
-        // Skip empty master tensors (HF Mamba identity input_proj). See
-        // `run_pairs` for the rationale.
-        if w.is_empty() {
-            continue;
-        }
-        if g.len() != w.len() {
-            return Err(format!(
-                "adamw: weight/grad len mismatch: w={} g={}",
-                w.len(),
-                g.len()
-            ));
-        }
-        let g_ptr = g.ptr();
-        let off_bytes = g_ptr - flat_grad_base;
-        let off_elems = off_bytes / 4;
-        let m_ptr = m_base + off_bytes;
-        let v_ptr = v_base + off_bytes;
-        debug_assert!(
-            off_elems as usize + g.len() <= adam.m.len(),
-            "adamw m/v slice OOB"
-        );
-        adam.step_one_capturable(
+    for pair in pairs {
+        run_one_capturable_wd(
             ctx,
             adamw_kernel,
-            AdamWParamPtrs {
-                weight: w.cached_ptr(),
-                grad: g_ptr,
-                m: m_ptr,
-                v: v_ptr,
-            },
+            adam,
             bias_factors_ptr,
-            g.len(),
+            flat_grad_base,
+            *pair,
+            adam.weight_decay,
         )?;
     }
     Ok(())
+}
+
+/// One capturable AdamW launch for a (weight, grad-slice) pair with an
+/// explicit weight decay. Shared body of [`run_pairs_capturable`] and the
+/// per-tensor no-decay paths in [`step_m1_capturable`] /
+/// [`step_m3_capturable`].
+fn run_one_capturable_wd(
+    ctx: &GpuCtx,
+    adamw_kernel: &CudaFunction,
+    adam: &GpuAdamW,
+    bias_factors_ptr: cudarc::driver::sys::CUdeviceptr,
+    flat_grad_base: cudarc::driver::sys::CUdeviceptr,
+    (w, g): (&GpuBuffer, &GradSlice),
+    weight_decay: f32,
+) -> Result<(), String> {
+    // Skip empty master tensors (HF Mamba identity input_proj). See
+    // `run_pairs` for the rationale.
+    if w.is_empty() {
+        return Ok(());
+    }
+    if g.len() != w.len() {
+        return Err(format!(
+            "adamw: weight/grad len mismatch: w={} g={}",
+            w.len(),
+            g.len()
+        ));
+    }
+    let g_ptr = g.ptr();
+    let off_bytes = g_ptr - flat_grad_base;
+    let off_elems = off_bytes / 4;
+    let m_ptr = adam.m.cached_ptr() + off_bytes;
+    let v_ptr = adam.v.cached_ptr() + off_bytes;
+    debug_assert!(
+        off_elems as usize + g.len() <= adam.m.len(),
+        "adamw m/v slice OOB"
+    );
+    adam.step_one_capturable_wd(
+        ctx,
+        adamw_kernel,
+        AdamWParamPtrs {
+            weight: w.cached_ptr(),
+            grad: g_ptr,
+            m: m_ptr,
+            v: v_ptr,
+        },
+        bias_factors_ptr,
+        g.len(),
+        weight_decay,
+    )
 }
 
 /// Mamba SSM backbone AdamW step. Iterates the per-tensor master weights in
@@ -433,23 +498,42 @@ pub fn step_m1_capturable(
     grads: &crate::mamba_ssm::gpu::weights::GpuMambaGrads,
 ) -> Result<(), String> {
     let flat_base = grads.flat.cached_ptr();
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> = Vec::new();
-    pairs.push((&weights.input_proj_w, &grads.input_proj_w));
-    pairs.push((&weights.input_proj_b, &grads.input_proj_b));
+    // (weight, grad, reference-no-decay?). The no-decay group is the set the
+    // reference implementation marks `_no_weight_decay`: a_log, D, dt bias,
+    // plus every RMSNorm scale — active only when `adam.reference_no_decay`.
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> = Vec::new();
+    pairs.push((&weights.input_proj_w, &grads.input_proj_w, false));
+    pairs.push((&weights.input_proj_b, &grads.input_proj_b, false));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {
-        pairs.push((&lw.norm_weight, &lg.norm_weight));
-        pairs.push((&lw.in_proj_w, &lg.in_proj_w));
-        pairs.push((&lw.conv1d_weight, &lg.conv1d_weight));
-        pairs.push((&lw.conv1d_bias, &lg.conv1d_bias));
-        pairs.push((&lw.x_proj_w, &lg.x_proj_w));
-        pairs.push((&lw.dt_proj_w, &lg.dt_proj_w));
-        pairs.push((&lw.dt_proj_b, &lg.dt_proj_b));
-        pairs.push((&lw.a_log, &lg.a_log));
-        pairs.push((&lw.d_param, &lg.d_param));
-        pairs.push((&lw.out_proj_w, &lg.out_proj_w));
+        pairs.push((&lw.norm_weight, &lg.norm_weight, true));
+        pairs.push((&lw.in_proj_w, &lg.in_proj_w, false));
+        pairs.push((&lw.conv1d_weight, &lg.conv1d_weight, false));
+        pairs.push((&lw.conv1d_bias, &lg.conv1d_bias, false));
+        pairs.push((&lw.x_proj_w, &lg.x_proj_w, false));
+        pairs.push((&lw.dt_proj_w, &lg.dt_proj_w, false));
+        pairs.push((&lw.dt_proj_b, &lg.dt_proj_b, true));
+        pairs.push((&lw.a_log, &lg.a_log, true));
+        pairs.push((&lw.d_param, &lg.d_param, true));
+        pairs.push((&lw.out_proj_w, &lg.out_proj_w, false));
     }
-    pairs.push((&weights.norm_f_weight, &grads.norm_f_weight));
-    run_pairs_capturable(ctx, adamw_kernel, adam, bias_factors_ptr, flat_base, &pairs)
+    pairs.push((&weights.norm_f_weight, &grads.norm_f_weight, true));
+    for (w, g, no_decay) in pairs {
+        let wd = if no_decay && adam.reference_no_decay {
+            0.0
+        } else {
+            adam.weight_decay
+        };
+        run_one_capturable_wd(
+            ctx,
+            adamw_kernel,
+            adam,
+            bias_factors_ptr,
+            flat_base,
+            (w, g),
+            wd,
+        )?;
+    }
+    Ok(())
 }
 
 /// CUDA-Graph-capturable variant of [`step_m3`].
@@ -462,23 +546,43 @@ pub fn step_m3_capturable(
     grads: &crate::mamba3_siso::gpu::weights::GpuMamba3Grads,
 ) -> Result<(), String> {
     let flat_base = grads.flat.cached_ptr();
-    let mut pairs: Vec<(&GpuBuffer, &GradSlice)> = Vec::new();
-    pairs.push((&weights.input_proj_w, &grads.input_proj_w));
-    pairs.push((&weights.input_proj_b, &grads.input_proj_b));
+    // M3 no-decay group (mirror of the M1 set's principle): dt bias, D and
+    // every norm scale. M3 has no fixed a_log (A is input-dependent); the
+    // B/C biases stay decayed (only the reference-named analogues are
+    // exempted). Active only when `adam.reference_no_decay`.
+    let mut pairs: Vec<(&GpuBuffer, &GradSlice, bool)> = Vec::new();
+    pairs.push((&weights.input_proj_w, &grads.input_proj_w, false));
+    pairs.push((&weights.input_proj_b, &grads.input_proj_b, false));
     for (lw, lg) in weights.layers.iter().zip(&grads.layers) {
-        pairs.push((&lw.norm_weight, &lg.norm_weight));
-        pairs.push((&lw.in_proj_w, &lg.in_proj_w));
-        pairs.push((&lw.dt_bias, &lg.dt_bias));
-        pairs.push((&lw.b_norm_weight, &lg.b_norm_weight));
-        pairs.push((&lw.c_norm_weight, &lg.c_norm_weight));
-        pairs.push((&lw.b_bias, &lg.b_bias));
-        pairs.push((&lw.c_bias, &lg.c_bias));
-        pairs.push((&lw.d_param, &lg.d_param));
-        pairs.push((&lw.norm_gate_weight, &lg.norm_gate_weight));
-        pairs.push((&lw.out_proj_w, &lg.out_proj_w));
+        pairs.push((&lw.norm_weight, &lg.norm_weight, true));
+        pairs.push((&lw.in_proj_w, &lg.in_proj_w, false));
+        pairs.push((&lw.dt_bias, &lg.dt_bias, true));
+        pairs.push((&lw.b_norm_weight, &lg.b_norm_weight, true));
+        pairs.push((&lw.c_norm_weight, &lg.c_norm_weight, true));
+        pairs.push((&lw.b_bias, &lg.b_bias, false));
+        pairs.push((&lw.c_bias, &lg.c_bias, false));
+        pairs.push((&lw.d_param, &lg.d_param, true));
+        pairs.push((&lw.norm_gate_weight, &lg.norm_gate_weight, true));
+        pairs.push((&lw.out_proj_w, &lg.out_proj_w, false));
     }
-    pairs.push((&weights.norm_f_weight, &grads.norm_f_weight));
-    run_pairs_capturable(ctx, adamw_kernel, adam, bias_factors_ptr, flat_base, &pairs)
+    pairs.push((&weights.norm_f_weight, &grads.norm_f_weight, true));
+    for (w, g, no_decay) in pairs {
+        let wd = if no_decay && adam.reference_no_decay {
+            0.0
+        } else {
+            adam.weight_decay
+        };
+        run_one_capturable_wd(
+            ctx,
+            adamw_kernel,
+            adam,
+            bias_factors_ptr,
+            flat_base,
+            (w, g),
+            wd,
+        )?;
+    }
+    Ok(())
 }
 
 /// Mamba-3 backbone AdamW step. Same idea as [`step_m1`] but for the M3

--- a/src/mamba_ssm/gpu/backward.rs
+++ b/src/mamba_ssm/gpu/backward.rs
@@ -593,7 +593,7 @@ pub fn gpu_backward_mamba_backbone(
 
 /// Scratch buffers for GPU Mamba target forward (batched B*T pipeline).
 ///
-/// Uses nosave burnin kernels (no h_saved/da_exp/conv_states writes).
+/// Uses nosave burnin kernels (no h_saved/conv_states writes).
 /// Per-layer conv/SSM state via flat buffers with layer offsets (matches online).
 ///
 /// Uses batched B*T pipeline instead of per-sample step-by-step approach.

--- a/src/mamba_ssm/gpu/backward_mixed.rs
+++ b/src/mamba_ssm/gpu/backward_mixed.rs
@@ -9,7 +9,7 @@
 //!   (residual) and writes f32 `dx` directly into the residual gradient —
 //!   no extra cast round-trip. Matches PyTorch AMP `residual_in_fp32=True`
 //!   and state-spaces/mamba `residual = residual.to(torch.float32)`.
-//! - **BPTT state (`h_saved`, `conv_states`, `da_exp`) stays f32**. The
+//! - **BPTT state (`h_saved`, `conv_states`) stays f32**. The
 //!   `ssm_backward_local_typed` kernel promotes typed `delta/u/B/C` on load
 //!   but keeps all scan variables in f32.
 //! - **T-length accumulators (`d_D_local`, `d_a_log_local`) stay f32**.

--- a/src/mamba_ssm/gpu/backward_mixed.rs
+++ b/src/mamba_ssm/gpu/backward_mixed.rs
@@ -868,12 +868,71 @@ pub fn gpu_backward_mamba_backbone_mixed(
         )?;
     }
 
-    // input_proj backward — identity-proj path only (matches forward_mixed).
+    // input_proj backward — identity leaves it untouched; non-identity
+    // computes dW/db only. The dX below the projection is deliberately
+    // discarded (nothing trainable sits under it; the future plumb-through's
+    // landing site is `scratch.d_input_proj_dx`).
     if mamba_w.input_proj_w.len_elems() != 0 {
-        return Err(
-            "mixed backward: non-identity input_proj not yet supported (matches forward_mixed)"
-                .into(),
-        );
+        let bt = dims.batch * dims.seq_len;
+        let dm = dims.d_model;
+        let mid = dims.mamba_input_dim;
+        // d_temporal now holds the f32 gradient w.r.t. the input_proj
+        // OUTPUT (every layer's dX has been folded back into it). Cast it
+        // to the compute dtype, reusing the saved typed OUTPUTS buffer —
+        // its forward value has no remaining consumer.
+        let dy_ptr = acts.input_proj_outputs.cached_ptr();
+        {
+            let n = (bt * dm) as i32;
+            let cast = match dtype {
+                WeightDtype::Bf16 => &ctx.kernels.cast_f32_to_bf16,
+                WeightDtype::F16 => &ctx.kernels.cast_f32_to_f16,
+                WeightDtype::F32 => {
+                    return Err("mixed backward: unexpected f32 compute dtype".into());
+                }
+            };
+            let src = d_temporal.cached_ptr();
+            let mut bld = ctx.stream.launch_builder(cast);
+            bld.arg(&dy_ptr);
+            bld.arg(&src);
+            bld.arg(&n);
+            unsafe { bld.launch(grid_1d(bt * dm)) }
+                .map_err(|e| format!("input_proj dY cast: {e:?}"))?;
+        }
+        // db: typed accumulating reduction of dY over (b, t) into the f32
+        // grad slice (deterministic — one block per bias index, no atomics).
+        {
+            let bt_i = bt as i32;
+            let dm_i = dm as i32;
+            let mut bld = ctx
+                .stream
+                .launch_builder(ctx.kernels.reduce_bias_typed.get(dtype));
+            let db = d_mamba.input_proj_b.ptr();
+            bld.arg(&db);
+            bld.arg(&dy_ptr);
+            bld.arg(&bt_i);
+            bld.arg(&dm_i);
+            let threads = 256u32;
+            let cfg = cudarc::driver::LaunchConfig {
+                grid_dim: (dm as u32, 1, 1),
+                block_dim: (threads, 1, 1),
+                shared_mem_bytes: (threads as usize * std::mem::size_of::<f32>()) as u32,
+            };
+            unsafe { bld.launch(cfg) }.map_err(|e| format!("reduce_bias input_proj: {e:?}"))?;
+        }
+        // dW: saved typed inputs^T @ dY, accumulated into the f32 grad
+        // slice (bi-deterministic or cuBLAS, routed inside the helper).
+        gpu_sgemm_backward_dw_grad_typed(
+            ctx,
+            &d_mamba.input_proj_w,
+            TypedPtr { ptr: dy_ptr, dtype },
+            TypedPtr {
+                ptr: acts.input_proj_inputs.cached_ptr(),
+                dtype,
+            },
+            bt,
+            mid,
+            dm,
+        )?;
     }
     Ok(())
 }

--- a/src/mamba_ssm/gpu/buffers.rs
+++ b/src/mamba_ssm/gpu/buffers.rs
@@ -449,6 +449,26 @@ impl GpuByteBuffer {
             .memset_zeros(&mut self.data)
             .map_err(|e| format!("GPU op failed: {:?}", e))
     }
+
+    /// Download the buffer contents as f64 values (the buffer must hold
+    /// exactly `dst.len()` f64s). Used for the grad-clip norm partials.
+    pub fn download_f64(
+        &self,
+        stream: &Arc<cudarc::driver::CudaStream>,
+        dst: &mut [f64],
+    ) -> Result<(), String> {
+        assert_eq!(
+            std::mem::size_of_val(dst),
+            self.len_bytes,
+            "download_f64 size mismatch: dst={} f64s, gpu={} bytes",
+            dst.len(),
+            self.len_bytes
+        );
+        let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst);
+        stream
+            .memcpy_dtoh(&self.data, bytes)
+            .map_err(|e| format!("GPU op failed: {:?}", e))
+    }
 }
 
 /// Dtype-aware owning buffer — holds activation scratch in any dtype.

--- a/src/mamba_ssm/gpu/context.rs
+++ b/src/mamba_ssm/gpu/context.rs
@@ -183,6 +183,40 @@ impl GpuCtx {
         self.with_bi_upcast_scratch((elems, elems, elems), |_, _, _| Ok(()))
     }
 
+    /// [`Self::presize_bi_upcast_scratch_for_train`] for a trainable
+    /// NON-IDENTITY input projection: extends the sizing bound with the
+    /// input_proj GEMM operands — the `m·input_dim` activation slot and the
+    /// `input_dim·d_model` weight. Without this, an `input_dim` (e.g. a
+    /// vision patch dim P²) exceeding `max(d_model, 2·d_inner, xproj_out)`
+    /// makes `with_bi_upcast_scratch` grow INSIDE CUDA Graph capture
+    /// (illegal alloc) or after it (freed-pointer replay). With
+    /// `input_dim <= d_model` (incl. identity) the bound equals the base
+    /// function's.
+    pub fn presize_bi_upcast_scratch_for_train_with_input(
+        &self,
+        cfg: &MambaConfig,
+        batch: usize,
+        seq_len: usize,
+        input_dim: usize,
+        dtype: WeightDtype,
+    ) -> Result<(), String> {
+        if matches!(dtype, WeightDtype::F32) || !self.batch_invariant() {
+            return Ok(());
+        }
+        let m = batch * seq_len;
+        let dm = cfg.d_model;
+        let di = cfg.d_inner();
+        let xproj_out = cfg.dt_rank() + 2 * cfg.d_state;
+        let max_dim = dm.max(2 * di).max(xproj_out).max(input_dim);
+        let max_kn = (dm * 2 * di)
+            .max(di * xproj_out)
+            .max(cfg.dt_rank() * di)
+            .max(di * dm)
+            .max(input_dim * dm);
+        let elems = (m * max_dim).max(max_kn);
+        self.with_bi_upcast_scratch((elems, elems, elems), |_, _, _| Ok(()))
+    }
+
     /// Mamba-3 twin of [`Self::presize_bi_upcast_scratch_for_train`] — the
     /// M3 step GEMMs are in_proj (`d_model → in_proj_out_dim`) and
     /// out_proj (`d_inner → d_model`).

--- a/src/mamba_ssm/gpu/forward.rs
+++ b/src/mamba_ssm/gpu/forward.rs
@@ -126,20 +126,6 @@ pub struct GpuMambaLayerActs {
     /// index 0 = initial state, index t+1 = state after step t.
     /// Layout: `[B * (T+1) * d_inner * d_state]`.
     pub h_saved: GpuBuffer,
-    /// Discretization exponential `exp(delta * A)` `[B*T*d_inner*d_state]`.
-    ///
-    /// **DEAD ALLOCATION** — kernels `ssm_burnin_forward`,
-    /// `ssm_parallel_scan_fwd` and their typed variants NEVER write this
-    /// buffer (the `da_exp_out` argument is ignored, see comments at the
-    /// kernel top). Backward recomputes `da` from saved `delta + a_neg`
-    /// on the fly. Kept as a named field and kernel argument for ABI
-    /// stability; planned removal once the kernel signatures are
-    /// refactored across all four dtypes × f32/parallel variants.
-    ///
-    /// Size at typical configs is significant: e.g. `B=32, T=32, d_inner=512,
-    /// d_state=16, n_layers=3` → ~1 GB wasted per trainer instance. Do
-    /// NOT rely on the contents for any computation.
-    pub da_exp: GpuBuffer,
     /// SSM output before gating `[B*T*d_inner]`.
     pub y: GpuBuffer,
 
@@ -200,7 +186,6 @@ impl GpuMambaBackboneActs {
                     delta: GpuBuffer::zeros(stream, bt * d_inner)?,
                     // F4d: SSM — h_saved has T+1 entries
                     h_saved: GpuBuffer::zeros(stream, batch * (seq_len + 1) * d_inner * d_state)?,
-                    da_exp: GpuBuffer::zeros(stream, bt * d_inner * d_state)?,
                     y: GpuBuffer::zeros(stream, bt * d_inner)?,
                     // F4e: Gating
                     gated: GpuBuffer::zeros(stream, bt * d_inner)?,
@@ -585,7 +570,6 @@ pub fn gpu_forward_mamba_layer(
             builder.arg(&layer_ptrs.ssm_state);
             builder.arg(acts.y.inner_mut());
             builder.arg(acts.h_saved.inner_mut());
-            builder.arg(acts.da_exp.inner_mut());
             builder.arg(acts.delta.inner());
             builder.arg(acts.u.inner());
             builder.arg(scratch.d_b_reduced.inner());
@@ -605,7 +589,6 @@ pub fn gpu_forward_mamba_layer(
             builder.arg(&layer_ptrs.ssm_state);
             builder.arg(acts.y.inner_mut());
             builder.arg(acts.h_saved.inner_mut());
-            builder.arg(acts.da_exp.inner_mut());
             builder.arg(acts.delta.inner());
             builder.arg(acts.u.inner());
             builder.arg(scratch.d_b_reduced.inner());

--- a/src/mamba_ssm/gpu/forward_mixed.rs
+++ b/src/mamba_ssm/gpu/forward_mixed.rs
@@ -362,11 +362,66 @@ pub fn gpu_forward_mamba_backbone_mixed(
             return Err(format!("identity proj D2D failed: {res:?}"));
         }
     } else {
-        return Err(
-            "non-identity input_proj for mixed training not yet implemented \
-             (HF Mamba uses identity_proj — use from_hf path)"
-                .to_string(),
-        );
+        // Non-identity input_proj — the trainable patch-embed path. Three
+        // launches: (1) cast the f32 input to the compute dtype, SAVED in
+        // acts (the backward dW consumes it); (2) typed GEMM with the f32
+        // bias into the saved typed outputs; (3) upcast the outputs to seed
+        // the f32 residual stream (AMP residual_in_fp32 — norm math and
+        // every residual carry stay f32).
+        let mid = dims.mamba_input_dim;
+        {
+            let n = (bt * mid) as i32;
+            let cast = match dt {
+                WeightDtype::Bf16 => &k.cast_f32_to_bf16,
+                WeightDtype::F16 => &k.cast_f32_to_f16,
+                WeightDtype::F32 => {
+                    return Err("mixed forward: unexpected f32 compute dtype".into());
+                }
+            };
+            let dst = acts.input_proj_inputs.cached_ptr();
+            let src = mamba_input.cached_ptr();
+            let mut bld = ctx.stream.launch_builder(cast);
+            bld.arg(&dst);
+            bld.arg(&src);
+            bld.arg(&n);
+            unsafe { bld.launch(grid_1d(bt * mid)) }
+                .map_err(|e| format!("input_proj input cast: {e:?}"))?;
+        }
+        gpu_gemm_typed_forward_raw(
+            ctx,
+            TypedPtr {
+                ptr: acts.input_proj_outputs.cached_ptr(),
+                dtype: dt,
+            },
+            TypedPtr {
+                ptr: acts.input_proj_inputs.cached_ptr(),
+                dtype: dt,
+            },
+            TypedPtr {
+                ptr: mamba_w.input_proj_w.ptr(),
+                dtype: dt,
+            },
+            Some(mamba_w.input_proj_b.ptr()),
+            (bt, mid, dm),
+        )?;
+        {
+            let n = (bt * dm) as i32;
+            let cast = match dt {
+                WeightDtype::Bf16 => &k.cast_bf16_to_f32,
+                WeightDtype::F16 => &k.cast_f16_to_f32,
+                WeightDtype::F32 => {
+                    return Err("mixed forward: unexpected f32 compute dtype".into());
+                }
+            };
+            let dst = acts.layers[0].residual.cached_ptr();
+            let src = acts.input_proj_outputs.cached_ptr();
+            let mut bld = ctx.stream.launch_builder(cast);
+            bld.arg(&dst);
+            bld.arg(&src);
+            bld.arg(&n);
+            unsafe { bld.launch(grid_1d(bt * dm)) }
+                .map_err(|e| format!("input_proj residual upcast: {e:?}"))?;
+        }
     }
 
     // ─── Per-layer offsets into flat state buffers ───

--- a/src/mamba_ssm/gpu/forward_mixed.rs
+++ b/src/mamba_ssm/gpu/forward_mixed.rs
@@ -9,7 +9,7 @@
 //! Precision rules:
 //! - **f32 always**: `residual` (residual stream), `rms_vals`/`norm_f_rms`
 //!   (reduction stats), `conv_states` (recurrent state), `h_saved` (BPTT
-//!   carry), `da_exp` (state-derived).
+//!   carry).
 //! - **typed (bf16/f16/f32)**: `post_norm`, `gate_pre_silu`, `gate_post_silu`,
 //!   `post_conv`, `u`, `xdbl`, `delta_raw`, `delta`, `y`, `gated`,
 //!   `input_proj_inputs`, `input_proj_outputs`, `norm_f_input` — these are
@@ -57,8 +57,6 @@ pub struct GpuMambaLayerMixedActs {
     /// f32 — hidden state saved BEFORE each step (T+1 entries)
     /// `[B*(T+1)*d_inner*d_state]`. STAYS f32 (BPTT recurrence).
     pub h_saved: GpuBuffer,
-    /// f32 — discretization `exp(delta * A)` `[B*T*d_inner*d_state]`.
-    pub da_exp: GpuBuffer,
     /// typed — SSM output before gating `[B*T*d_inner]`.
     pub y: DtypedBuf,
     /// typed — gated output `y * gate_silu` `[B*T*d_inner]`.
@@ -111,7 +109,6 @@ impl GpuMambaBackboneMixedActs {
                     rms_vals: GpuBuffer::zeros(stream, bt)?,
                     conv_states: GpuBuffer::zeros(stream, bt * d_inner * d_conv)?,
                     h_saved: GpuBuffer::zeros(stream, batch * (seq_len + 1) * d_inner * d_state)?,
-                    da_exp: GpuBuffer::zeros(stream, bt * d_inner * d_state)?,
                     // typed — GEMM I/O / elementwise
                     post_norm: DtypedBuf::zeros(stream, bt * d_model, dtype)?,
                     gate_pre_silu: DtypedBuf::zeros(stream, bt * d_inner, dtype)?,
@@ -629,7 +626,7 @@ pub fn gpu_forward_mamba_backbone_mixed(
         }
         // SSM forward: parallel prefix scan for T > PARALLEL_SCAN_THRESHOLD
         // or ds > 64 (matches f32 path dispatch in forward.rs:544). Typed
-        // variants (Step 8b) keep scan state + h_saved + da_exp + smem f32
+        // variants (Step 8b) keep scan state + h_saved + smem f32
         // per state-spaces/mamba `scan_t = float2` invariant; only
         // delta/u/B/C/y are typed.
         {
@@ -642,7 +639,6 @@ pub fn gpu_forward_mamba_backbone_mixed(
                 let mut bld = ctx.stream.launch_builder(kernel);
                 let y = layer_acts.y.cached_ptr();
                 let hs = layer_acts.h_saved.cached_ptr();
-                let dae = layer_acts.da_exp.cached_ptr();
                 let dl = layer_acts.delta.cached_ptr();
                 let u = layer_acts.u.cached_ptr();
                 let bb = scratch.b_buf.cached_ptr();
@@ -651,7 +647,6 @@ pub fn gpu_forward_mamba_backbone_mixed(
                 bld.arg(&ssm_ptr);
                 bld.arg(&y);
                 bld.arg(&hs);
-                bld.arg(&dae);
                 bld.arg(&dl);
                 bld.arg(&u);
                 bld.arg(&bb);
@@ -683,7 +678,6 @@ pub fn gpu_forward_mamba_backbone_mixed(
                 let mut bld = ctx.stream.launch_builder(kernel);
                 let y = layer_acts.y.cached_ptr();
                 let hs = layer_acts.h_saved.cached_ptr();
-                let dae = layer_acts.da_exp.cached_ptr();
                 let dl = layer_acts.delta.cached_ptr();
                 let u = layer_acts.u.cached_ptr();
                 let bb = scratch.b_buf.cached_ptr();
@@ -692,7 +686,6 @@ pub fn gpu_forward_mamba_backbone_mixed(
                 bld.arg(&ssm_ptr);
                 bld.arg(&y);
                 bld.arg(&hs);
-                bld.arg(&dae);
                 bld.arg(&dl);
                 bld.arg(&u);
                 bld.arg(&bb);

--- a/src/mamba_ssm/gpu/grad_clip.rs
+++ b/src/mamba_ssm/gpu/grad_clip.rs
@@ -1,0 +1,96 @@
+//! Deterministic global-norm gradient clipping — host side.
+//!
+//! The norm is computed by the fixed-grid `grad_sumsq_partial_f32` kernel
+//! (kernels/grad_clip.cu): 512 blocks x 256 threads, fixed-stride element
+//! assignment, per-thread f64 accumulation, fixed shared-memory tree reduce,
+//! one f64 partial per block. The host then sums the 512 partials in order
+//! and takes the square root — no atomics anywhere, so the norm is
+//! bit-stable across runs. Scaling reuses the existing `scale_grads_f32`
+//! elementwise kernel with the PyTorch `clip_grad_norm_` coefficient
+//! `max_norm / (norm + 1e-6)`.
+//!
+//! This is an EAGER-path facility (the split `backward_step`): the norm is
+//! an inherent host sync point. The fused captured step never computes it.
+
+use std::sync::Arc;
+
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+
+use super::buffers::{GpuBuffer, GpuByteBuffer};
+use super::context::GpuCtx;
+use super::launch::grid_1d;
+
+/// Number of f64 partials the fixed-grid reduction produces. Must match
+/// `GCLIP_BLOCKS` in kernels/grad_clip.cu.
+pub const GRAD_CLIP_PARTIALS: usize = 512;
+
+/// Threads per block of the reduction kernel. Must match `GCLIP_THREADS`
+/// in kernels/grad_clip.cu.
+const GRAD_CLIP_THREADS: u32 = 256;
+
+/// Allocate the device-side partials buffer the norm kernel writes into.
+pub fn alloc_partials(stream: &Arc<cudarc::driver::CudaStream>) -> Result<GpuByteBuffer, String> {
+    GpuByteBuffer::zeros(stream, GRAD_CLIP_PARTIALS * std::mem::size_of::<f64>())
+}
+
+/// Compute the global L2 norm of the flat grad arena. Deterministic
+/// (fixed-order reduction, f64 accumulation); synchronizes the stream
+/// before the partials download.
+pub fn global_grad_norm(
+    ctx: &GpuCtx,
+    grads_flat: &GpuBuffer,
+    partials: &mut GpuByteBuffer,
+    partials_host: &mut [f64],
+) -> Result<f64, String> {
+    assert_eq!(
+        partials.len_bytes(),
+        GRAD_CLIP_PARTIALS * std::mem::size_of::<f64>(),
+        "grad-clip partials buffer has the wrong size"
+    );
+    assert_eq!(
+        partials_host.len(),
+        GRAD_CLIP_PARTIALS,
+        "grad-clip host partials slice has the wrong length"
+    );
+    let n = grads_flat.len() as i32;
+    let dst = partials.cached_ptr();
+    let src = grads_flat.cached_ptr();
+    let mut b = ctx
+        .stream
+        .launch_builder(&ctx.kernels.grad_sumsq_partial_f32);
+    b.arg(&dst);
+    b.arg(&src);
+    b.arg(&n);
+    // Geometry is part of the kernel's determinism contract — always the
+    // full fixed grid, independent of n.
+    let launch_cfg = LaunchConfig {
+        grid_dim: (GRAD_CLIP_PARTIALS as u32, 1, 1),
+        block_dim: (GRAD_CLIP_THREADS, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    unsafe { b.launch(launch_cfg) }.map_err(|e| format!("grad_sumsq_partial_f32: {e:?}"))?;
+    ctx.stream
+        .synchronize()
+        .map_err(|e| format!("grad norm sync: {e:?}"))?;
+    partials.download_f64(&ctx.stream, partials_host)?;
+    // Ordered host sum — the final, fixed-order reduction stage.
+    let mut sum = 0.0f64;
+    for &p in partials_host.iter() {
+        sum += p;
+    }
+    Ok(sum.sqrt())
+}
+
+/// In-place multiply of the flat grad arena by `factor` (the clip
+/// coefficient). Reuses the AMP `scale_grads_f32` kernel.
+pub fn scale_grads(ctx: &GpuCtx, grads_flat: &mut GpuBuffer, factor: f32) -> Result<(), String> {
+    let n_elems = grads_flat.len();
+    let n = n_elems as i32;
+    let mut b = ctx.stream.launch_builder(&ctx.kernels.scale_grads_f32);
+    b.arg(grads_flat.inner_mut());
+    b.arg(&factor);
+    b.arg(&n);
+    unsafe { b.launch(grid_1d(n_elems)) }
+        .map(|_| ())
+        .map_err(|e| format!("scale_grads (clip): {e:?}"))
+}

--- a/src/mamba_ssm/gpu/kernels.rs
+++ b/src/mamba_ssm/gpu/kernels.rs
@@ -271,6 +271,10 @@ pub struct MambaKernels {
     /// CUDA-Graph-capturable conditional unscale: zeros grads if the
     /// overflow flag is set, otherwise multiplies by 1/loss_scale (Step 22).
     pub scale_grads_skip_f32: CudaFunction,
+    /// Deterministic global-norm support: fixed-grid sum-of-squares partial
+    /// reduction with f64 accumulators (kernels/grad_clip.cu). The host sums
+    /// the fixed 512 partials in order; scaling reuses `scale_grads_f32`.
+    pub grad_sumsq_partial_f32: CudaFunction,
 
     // -- AdamW optimizer (Step 12) --
     /// Fused AdamW step on f32 master weights + f32 optimizer state.
@@ -390,6 +394,7 @@ impl MambaKernels {
             include_str!("../../../kernels/norms.cu"),
             include_str!("../../../kernels/elementwise.cu"),
             include_str!("../../../kernels/loss_scaler.cu"),
+            include_str!("../../../kernels/grad_clip.cu"),
             include_str!("../../../kernels/adamw.cu"),
             include_str!("../../../kernels/gemm_batch_invariant.cu"),
             include_str!("../../../kernels/sgemm_bi.cu"),
@@ -545,6 +550,7 @@ impl MambaKernels {
             check_inf_nan_f32: get("check_inf_nan_f32")?,
             scale_grads_f32: get("scale_grads_f32")?,
             scale_grads_skip_f32: get("scale_grads_skip_f32")?,
+            grad_sumsq_partial_f32: get("grad_sumsq_partial_f32")?,
 
             // AdamW
             adamw_step_f32: get("adamw_step_f32")?,

--- a/src/mamba_ssm/gpu/mod.rs
+++ b/src/mamba_ssm/gpu/mod.rs
@@ -19,6 +19,7 @@ pub mod device;
 pub mod dtype;
 pub mod forward;
 pub mod forward_mixed;
+pub mod grad_clip;
 pub mod graph_capture;
 pub mod inference;
 pub mod kernels;

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -609,16 +609,6 @@ impl MambaTrainerMixed {
         session: TrainSessionCfg,
         dtype: WeightDtype,
     ) -> Result<Self, String> {
-        // Fail at construction, not on the first step(): the mixed forward
-        // only implements the identity-input_proj branch today.
-        if !cpu_weights.input_proj_w.is_empty() {
-            return Err(
-                "MambaTrainerMixed: non-identity input_proj is not yet supported in the \
-                 mixed-precision pipeline — clear input_proj_w/input_proj_b (identity \
-                 D2D branch) or train with WeightDtype::F32"
-                    .into(),
-            );
-        }
         let TrainSessionCfg {
             input_dim,
             batch,

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -48,7 +48,7 @@ use crate::config::MambaConfig;
 use crate::mamba_ssm::gpu::adamw::{AdamWBiasFactors, GpuAdamW, step_m1_capturable};
 use crate::mamba_ssm::gpu::backward::gpu_backward_mamba_backbone;
 use crate::mamba_ssm::gpu::backward_mixed::gpu_backward_mamba_backbone_mixed;
-use crate::mamba_ssm::gpu::buffers::GpuBuffer;
+use crate::mamba_ssm::gpu::buffers::{GpuBuffer, GpuByteBuffer};
 use crate::mamba_ssm::gpu::context::GpuCtx;
 use crate::mamba_ssm::gpu::device::GpuDevice;
 use crate::mamba_ssm::gpu::dtype::WeightDtype;
@@ -58,6 +58,9 @@ use crate::mamba_ssm::gpu::forward::{
 };
 use crate::mamba_ssm::gpu::forward_mixed::{
     GpuMambaBackboneMixedActs, GpuMambaMixedTrainScratch, gpu_forward_mamba_backbone_train_mixed,
+};
+use crate::mamba_ssm::gpu::grad_clip::{
+    GRAD_CLIP_PARTIALS, alloc_partials, global_grad_norm, scale_grads,
 };
 use crate::mamba_ssm::gpu::graph_capture::capture_into_graph;
 use crate::mamba_ssm::gpu::launch::grid_1d;
@@ -173,9 +176,11 @@ impl StepMetrics {
 pub struct BackwardOpts {
     /// `Some(c)`: after backward (and, for f16, after unscale) scale the
     /// gradients by `min(1, c / (||g||_2 + 1e-6))` before AdamW —
-    /// `torch.nn.utils.clip_grad_norm_` semantics. NOT WIRED YET: returns
-    /// an error until the deterministic `grad_clip` kernel lands (the next
-    /// step of this branch).
+    /// `torch.nn.utils.clip_grad_norm_` semantics. The norm is computed by
+    /// a deterministic fixed-order f64 reduction and returned in
+    /// [`BackwardMetrics::grad_norm`]. A non-finite norm is an error.
+    /// Incompatible with `accumulate_only` (the norm is only defined over
+    /// the complete accumulated gradient — clip on the applying call).
     pub clip_max_norm: Option<f32>,
     /// `true`: accumulate only — the gradient arena is NOT zeroed by the
     /// next `backward_step`, Adam does not advance, and AdamW /
@@ -487,6 +492,10 @@ pub(crate) struct MambaTrainerMixed {
     /// to run (its body zeroes the arena and would silently discard the
     /// accumulated gradients).
     grads_dirty: bool,
+    /// Device partials for the deterministic grad-clip norm (512 f64).
+    clip_partials: GpuByteBuffer,
+    /// Host mirror of the partials — pre-allocated (zero-alloc hot path).
+    clip_partials_host: Vec<f64>,
 
     // Lazily-populated CUDA Graph. None → eager path; Some → replayed.
     // Always None for f16 (loss-scaler overflow check requires CPU readback,
@@ -626,6 +635,8 @@ impl MambaTrainerMixed {
             .synchronize()
             .map_err(|e| format!("sync: {e:?}"))?;
 
+        let clip_partials = alloc_partials(&ctx.stream)?;
+
         Ok(Self {
             ctx,
             cfg,
@@ -645,6 +656,8 @@ impl MambaTrainerMixed {
             temporal_f32,
             split_forward_pending: false,
             grads_dirty: false,
+            clip_partials,
+            clip_partials_host: vec![0.0; GRAD_CLIP_PARTIALS],
             graph: None,
             scaler,
             overflow_flag,
@@ -872,10 +885,11 @@ impl MambaTrainerMixed {
                     .into(),
             );
         }
-        if opts.clip_max_norm.is_some() {
+        if opts.clip_max_norm.is_some() && opts.accumulate_only {
             return Err(
-                "clip_max_norm is not wired yet — the deterministic grad_clip kernel \
-                 lands in the next step of this branch"
+                "clip_max_norm + accumulate_only is unsupported: the global norm is only \
+                 defined over the COMPLETE accumulated gradient — request the clip on the \
+                 final (applying) backward_step"
                     .into(),
             );
         }
@@ -895,7 +909,7 @@ impl MambaTrainerMixed {
                         .into(),
                 );
             }
-            let m = self.backward_split_f16(d_temporal)?;
+            let m = self.backward_split_f16(d_temporal, opts.clip_max_norm)?;
             self.split_forward_pending = false;
             return Ok(m);
         }
@@ -917,6 +931,10 @@ impl MambaTrainerMixed {
                 overflow_skipped: None,
             })
         } else {
+            let grad_norm = match opts.clip_max_norm {
+                Some(c) => Some(self.apply_clip(c)?),
+                None => None,
+            };
             let (step, bc1, bc2) = self.adam.advance();
             self.bias.write(&self.ctx.stream, bc1, bc2)?;
             self.eager_optimize()?;
@@ -924,17 +942,44 @@ impl MambaTrainerMixed {
             Ok(BackwardMetrics {
                 step,
                 optimizer_stepped: true,
-                grad_norm: None,
+                grad_norm,
                 loss_scale: None,
                 overflow_skipped: None,
             })
         }
     }
 
+    /// Compute the deterministic global grad norm, apply the clip
+    /// coefficient when needed, and return the PRE-clip norm.
+    fn apply_clip(&mut self, max_norm: f32) -> Result<f32, String> {
+        let norm = global_grad_norm(
+            &self.ctx,
+            &self.grads.flat,
+            &mut self.clip_partials,
+            &mut self.clip_partials_host,
+        )?;
+        if !norm.is_finite() {
+            return Err(format!(
+                "clip_max_norm: non-finite global grad norm ({norm})"
+            ));
+        }
+        let coef = max_norm as f64 / (norm + 1e-6);
+        if coef < 1.0 {
+            scale_grads(&self.ctx, &mut self.grads.flat, coef as f32)?;
+        }
+        Ok(norm as f32)
+    }
+
     /// f16 split backward: mirrors the `step_f16` eager branch minus the
     /// forward (GradScaler protocol — scale, backward, overflow check,
-    /// conditional unscale + optimize, scaler update, step rollback).
-    fn backward_split_f16(&mut self, d_temporal: &[f32]) -> Result<BackwardMetrics, String> {
+    /// conditional unscale + clip + optimize, scaler update, step rollback).
+    /// The clip norm is computed AFTER the unscale, per the
+    /// unscale-then-norm-then-clip ordering law.
+    fn backward_split_f16(
+        &mut self,
+        d_temporal: &[f32],
+        clip_max_norm: Option<f32>,
+    ) -> Result<BackwardMetrics, String> {
         let scale = self.scaler.as_ref().expect("f16 scaler").scale();
         {
             let dt_scaled = self.d_temporal_scaled.as_mut().expect("f16 dt_scaled");
@@ -975,6 +1020,7 @@ impl MambaTrainerMixed {
             .unwrap()
             .read(&self.ctx.stream)?
             != 0;
+        let mut grad_norm = None;
         if !overflow {
             let unscale = self.unscale_factor.as_ref().expect("unscale buf");
             scale_grads_skip_gpu(
@@ -984,6 +1030,9 @@ impl MambaTrainerMixed {
                 &mut self.grads.flat,
                 unscale,
             )?;
+            if let Some(c) = clip_max_norm {
+                grad_norm = Some(self.apply_clip(c)?);
+            }
             self.eager_optimize()?;
         }
         self.scaler.as_mut().expect("f16 scaler").update(overflow);
@@ -996,7 +1045,7 @@ impl MambaTrainerMixed {
         Ok(BackwardMetrics {
             step: final_step,
             optimizer_stepped: !overflow,
-            grad_norm: None,
+            grad_norm,
             loss_scale: Some(scale),
             overflow_skipped: Some(overflow),
         })
@@ -1371,6 +1420,10 @@ pub(crate) struct MambaTrainerF32 {
     /// True while an `accumulate_only` backward window is open (see the
     /// same-named field on `MambaTrainerMixed`).
     grads_dirty: bool,
+    /// Device partials for the deterministic grad-clip norm (512 f64).
+    clip_partials: GpuByteBuffer,
+    /// Host mirror of the partials — pre-allocated (zero-alloc hot path).
+    clip_partials_host: Vec<f64>,
 }
 
 impl MambaTrainerF32 {
@@ -1447,6 +1500,8 @@ impl MambaTrainerF32 {
             .synchronize()
             .map_err(|e| format!("sync: {e:?}"))?;
 
+        let clip_partials = alloc_partials(&ctx.stream)?;
+
         Ok(Self {
             ctx,
             cfg,
@@ -1466,6 +1521,8 @@ impl MambaTrainerF32 {
             graph: None,
             split_forward_pending: false,
             grads_dirty: false,
+            clip_partials,
+            clip_partials_host: vec![0.0; GRAD_CLIP_PARTIALS],
         })
     }
 
@@ -1608,10 +1665,11 @@ impl MambaTrainerF32 {
                     .into(),
             );
         }
-        if opts.clip_max_norm.is_some() {
+        if opts.clip_max_norm.is_some() && opts.accumulate_only {
             return Err(
-                "clip_max_norm is not wired yet — the deterministic grad_clip kernel \
-                 lands in the next step of this branch"
+                "clip_max_norm + accumulate_only is unsupported: the global norm is only \
+                 defined over the COMPLETE accumulated gradient — request the clip on the \
+                 final (applying) backward_step"
                     .into(),
             );
         }
@@ -1639,6 +1697,10 @@ impl MambaTrainerF32 {
                 overflow_skipped: None,
             })
         } else {
+            let grad_norm = match opts.clip_max_norm {
+                Some(c) => Some(self.apply_clip(c)?),
+                None => None,
+            };
             let (step, bc1, bc2) = self.adam.advance();
             self.bias.write(&self.ctx.stream, bc1, bc2)?;
             self.eager_optimize()?;
@@ -1646,7 +1708,7 @@ impl MambaTrainerF32 {
             Ok(BackwardMetrics {
                 step,
                 optimizer_stepped: true,
-                grad_norm: None,
+                grad_norm,
                 loss_scale: None,
                 overflow_skipped: None,
             })
@@ -1712,6 +1774,27 @@ impl MambaTrainerF32 {
         self.eager_forward()?;
         self.eager_backward()?;
         self.eager_optimize()
+    }
+
+    /// Compute the deterministic global grad norm, apply the clip
+    /// coefficient when needed, and return the PRE-clip norm.
+    fn apply_clip(&mut self, max_norm: f32) -> Result<f32, String> {
+        let norm = global_grad_norm(
+            &self.ctx,
+            &self.grads.flat,
+            &mut self.clip_partials,
+            &mut self.clip_partials_host,
+        )?;
+        if !norm.is_finite() {
+            return Err(format!(
+                "clip_max_norm: non-finite global grad norm ({norm})"
+            ));
+        }
+        let coef = max_norm as f64 / (norm + 1e-6);
+        if coef < 1.0 {
+            scale_grads(&self.ctx, &mut self.grads.flat, coef as f32)?;
+        }
+        Ok(norm as f32)
     }
 
     pub fn snapshot_master(&self) -> Result<MambaWeights, String> {

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -1304,6 +1304,17 @@ impl MambaTrainerMixed {
         // doesn't currently use it, but match the bf16 graph for parity).
         self.ctx
             .presize_half_staging_for_train(&self.cfg, self.batch, self.seq_len, self.dtype)?;
+        // Same for the bi upcast scratch (input_dim-aware): under the
+        // batch-invariant flag the captured body's typed GEMMs route through
+        // with_bi_upcast_scratch — a lazy grow inside capture is illegal.
+        let input_dim = self.mamba_input.len() / (self.batch * self.seq_len);
+        self.ctx.presize_bi_upcast_scratch_for_train_with_input(
+            &self.cfg,
+            self.batch,
+            self.seq_len,
+            input_dim,
+            self.dtype,
+        )?;
 
         // Snapshot every device pointer the captured kernels reference, so
         // step_f16 can assert pointer-stability on each replay (audit Step

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -701,9 +701,9 @@ impl MambaTrainerMixed {
         // then scale d_temporal on-device: the old path built a scaled
         // Vec<f32> on the host every step (B*T*d_model alloc + traversal).
         self.mamba_input.upload(&self.ctx.stream, input)?;
-        let dt_scaled = self.d_temporal_scaled.as_mut().expect("f16 dt_scaled");
-        dt_scaled.upload(&self.ctx.stream, d_temporal)?;
         {
+            let dt_scaled = self.d_temporal_scaled.as_mut().expect("f16 dt_scaled");
+            dt_scaled.upload(&self.ctx.stream, d_temporal)?;
             let n = d_temporal.len() as i32;
             let mut builder = self
                 .ctx
@@ -790,23 +790,8 @@ impl MambaTrainerMixed {
             // isn't supported — the `scale_grads_skip_f32` device-side
             // conditional + NaN-sanitization is the price paid there.
             self.grads.zero(&self.ctx.stream)?;
-            gpu_forward_mamba_backbone_train_mixed(
-                &self.ctx,
-                &mut self.acts,
-                &self.weights,
-                &self.mamba_input,
-                &mut self.state,
-                &mut self.scratch,
-            )?;
-            gpu_backward_mamba_backbone_mixed(
-                &self.ctx,
-                dt_scaled,
-                &self.grads,
-                &self.acts,
-                &self.weights.compute,
-                &self.a_neg_all,
-                &mut self.scratch,
-            )?;
+            self.eager_forward()?;
+            self.eager_backward(true)?;
             check_inf_nan_gpu(
                 &self.ctx,
                 &self.ctx.kernels,
@@ -830,23 +815,7 @@ impl MambaTrainerMixed {
                     &mut self.grads.flat,
                     unscale,
                 )?;
-                step_m1_capturable(
-                    &self.ctx,
-                    &self.ctx.kernels.adamw_step_f32_capturable,
-                    &self.adam,
-                    self.bias.ptr(),
-                    &mut self.weights.master,
-                    &self.grads,
-                )?;
-                self.weights.sync_master_to_compute(&self.ctx)?;
-                recompute_a_neg_all(
-                    &self.ctx,
-                    &self.weights.master.layers,
-                    &self.a_neg_all,
-                    &self.state.a_neg_all,
-                    self.cfg.d_inner(),
-                    self.cfg.d_state,
-                )?;
+                self.eager_optimize()?;
             }
             // else: overflow → skip AdamW entirely. Master weights, m/v
             // and a_neg all stay at the previous step's state, matching
@@ -921,23 +890,8 @@ impl MambaTrainerMixed {
         let stream = self.ctx.stream.clone();
         let g = capture_into_graph(&stream, || {
             self.grads.zero(&self.ctx.stream)?;
-            gpu_forward_mamba_backbone_train_mixed(
-                &self.ctx,
-                &mut self.acts,
-                &self.weights,
-                &self.mamba_input,
-                &mut self.state,
-                &mut self.scratch,
-            )?;
-            gpu_backward_mamba_backbone_mixed(
-                &self.ctx,
-                self.d_temporal_scaled.as_mut().unwrap(),
-                &self.grads,
-                &self.acts,
-                &self.weights.compute,
-                &self.a_neg_all,
-                &mut self.scratch,
-            )?;
+            self.eager_forward()?;
+            self.eager_backward(true)?;
             check_inf_nan_gpu(
                 &self.ctx,
                 &self.ctx.kernels,
@@ -951,25 +905,12 @@ impl MambaTrainerMixed {
                 &mut self.grads.flat,
                 self.unscale_factor.as_ref().unwrap(),
             )?;
-            step_m1_capturable(
-                &self.ctx,
-                &self.ctx.kernels.adamw_step_f32_capturable,
-                &self.adam,
-                self.bias.ptr(),
-                &mut self.weights.master,
-                &self.grads,
-            )?;
-            self.weights.sync_master_to_compute(&self.ctx)?;
-            // Recompute a_neg after AdamW so each replay sees the updated
-            // A-matrix (same rationale as the eager and bf16-graph paths).
-            recompute_a_neg_all(
-                &self.ctx,
-                &self.weights.master.layers,
-                &self.a_neg_all,
-                &self.state.a_neg_all,
-                self.cfg.d_inner(),
-                self.cfg.d_state,
-            )?;
+            // AdamW runs unconditionally in the captured body (branching
+            // mid-graph is unsupported); scale_grads_skip has already
+            // sanitized the arena on overflow. eager_optimize also recomputes
+            // a_neg after AdamW so each replay sees the updated A-matrix
+            // (same rationale as the eager and bf16-graph paths).
+            self.eager_optimize()?;
             Ok(())
         })?;
         self.graph_f16 = Some(g);
@@ -981,11 +922,11 @@ impl MambaTrainerMixed {
         Ok(())
     }
 
-    /// Eager fallback (used before [`Self::capture_graph`] is called and
-    /// shared as the body of capture). Mirrors the exact op sequence the
-    /// captured graph records.
-    fn step_eager(&mut self) -> Result<(), String> {
-        self.grads.zero(&self.ctx.stream)?;
+    /// Eager forward body: run the mixed training forward (saves the typed
+    /// activations backward reads). One of the three shared phase bodies the
+    /// fused eager step, the f16 eager step, and the f16 capture body all
+    /// compose; the forward/backward split API builds on exactly these seams.
+    fn eager_forward(&mut self) -> Result<(), String> {
         gpu_forward_mamba_backbone_train_mixed(
             &self.ctx,
             &mut self.acts,
@@ -993,19 +934,38 @@ impl MambaTrainerMixed {
             &self.mamba_input,
             &mut self.state,
             &mut self.scratch,
-        )?;
+        )
+    }
+
+    /// Eager backward body: accumulate gradients into the grad arena
+    /// (beta=1.0 — zeroing is the caller's responsibility). `scaled` selects
+    /// the f16 loss-scaled `d_temporal_scaled` buffer over the plain
+    /// `d_temporal` upload buffer.
+    fn eager_backward(&mut self, scaled: bool) -> Result<(), String> {
+        let d_temporal = if scaled {
+            self.d_temporal_scaled
+                .as_mut()
+                .expect("eager_backward(scaled): f16 d_temporal_scaled missing")
+        } else {
+            &mut self.d_temporal
+        };
         gpu_backward_mamba_backbone_mixed(
             &self.ctx,
-            &mut self.d_temporal,
+            d_temporal,
             &self.grads,
             &self.acts,
             &self.weights.compute,
             &self.a_neg_all,
             &mut self.scratch,
-        )?;
-        // Use the capturable kernel here too so the graph's and eager path's
-        // numerics are bit-identical (the kernel reads bias_factors from a
-        // device pointer that the `bias.write` above populated).
+        )
+    }
+
+    /// Eager optimizer tail: AdamW on the f32 master weights (capturable
+    /// kernel so graph and eager numerics stay bit-identical), master →
+    /// compute sync, then the mandatory `a_neg = -exp(a_log)` refresh
+    /// (without it the SSM reads a stale A-matrix and the a_log gradient is
+    /// a silent no-op — see `recompute_a_neg_all`).
+    fn eager_optimize(&mut self) -> Result<(), String> {
         step_m1_capturable(
             &self.ctx,
             &self.ctx.kernels.adamw_step_f32_capturable,
@@ -1015,11 +975,6 @@ impl MambaTrainerMixed {
             &self.grads,
         )?;
         self.weights.sync_master_to_compute(&self.ctx)?;
-        // a_log was just updated by AdamW — recompute a_neg = -exp(a_log)
-        // so the next forward sees the updated A-matrix. Without this, the
-        // SSM kernel reads stale decay values from construction time and
-        // the learned a_log gradient never reaches the recurrence (silent
-        // training no-op on the A-matrix).
         recompute_a_neg_all(
             &self.ctx,
             &self.weights.master.layers,
@@ -1027,8 +982,17 @@ impl MambaTrainerMixed {
             &self.state.a_neg_all,
             self.cfg.d_inner(),
             self.cfg.d_state,
-        )?;
-        Ok(())
+        )
+    }
+
+    /// Eager fallback (used before [`Self::capture_graph`] is called and
+    /// shared as the body of capture). Mirrors the exact op sequence the
+    /// captured graph records.
+    fn step_eager(&mut self) -> Result<(), String> {
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_forward()?;
+        self.eager_backward(false)?;
+        self.eager_optimize()
     }
 
     /// Download the master weights to a CPU-side `MambaWeights` for
@@ -1267,8 +1231,11 @@ impl MambaTrainerF32 {
         Ok(StepMetrics::plain(step, replayed))
     }
 
-    fn step_eager(&mut self) -> Result<(), String> {
-        self.grads.zero(&self.ctx.stream)?;
+    /// Eager forward body: run the training forward, writing the post-norm_f
+    /// output into `self.temporal`. One of the three shared phase bodies the
+    /// fused eager step composes; the forward/backward split API builds on
+    /// exactly these seams.
+    fn eager_forward(&mut self) -> Result<(), String> {
         gpu_forward_mamba_backbone(
             &self.ctx,
             &mut self.temporal,
@@ -1277,7 +1244,13 @@ impl MambaTrainerF32 {
             &self.mamba_input,
             &mut self.state,
             &mut self.scratch,
-        )?;
+        )
+    }
+
+    /// Eager backward body: accumulate gradients from `self.d_temporal`
+    /// through the saved activations into the grad arena (beta=1.0 —
+    /// zeroing is the caller's responsibility).
+    fn eager_backward(&mut self) -> Result<(), String> {
         gpu_backward_mamba_backbone(
             &self.ctx,
             &mut self.d_temporal,
@@ -1286,7 +1259,14 @@ impl MambaTrainerF32 {
             &self.weights,
             &self.a_neg_all,
             &mut self.scratch,
-        )?;
+        )
+    }
+
+    /// Eager optimizer tail: AdamW over the grad arena, then the mandatory
+    /// `a_neg = -exp(a_log)` refresh (without it the SSM reads a stale
+    /// A-matrix and the a_log gradient is a silent no-op — see
+    /// `recompute_a_neg_all`).
+    fn eager_optimize(&mut self) -> Result<(), String> {
         step_m1_capturable(
             &self.ctx,
             &self.ctx.kernels.adamw_step_f32_capturable,
@@ -1295,8 +1275,6 @@ impl MambaTrainerF32 {
             &mut self.weights,
             &self.grads,
         )?;
-        // Recompute a_neg after AdamW updated a_log — see docstring on
-        // `recompute_a_neg_all` above. Without this, SSM uses stale A-matrix.
         recompute_a_neg_all(
             &self.ctx,
             &self.weights.layers,
@@ -1304,8 +1282,14 @@ impl MambaTrainerF32 {
             &self.state.a_neg_all,
             self.cfg.d_inner(),
             self.cfg.d_state,
-        )?;
-        Ok(())
+        )
+    }
+
+    fn step_eager(&mut self) -> Result<(), String> {
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_forward()?;
+        self.eager_backward()?;
+        self.eager_optimize()
     }
 
     pub fn snapshot_master(&self) -> Result<MambaWeights, String> {

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -369,6 +369,30 @@ impl MambaTrainer {
         }
     }
 
+    /// Toggle the reference-faithful AdamW no-decay parameter groups
+    /// (`a_log` / `d_param` / `dt_proj_b` / RMSNorm scales get
+    /// `weight_decay = 0`, matching the reference `_no_weight_decay`
+    /// marks — decaying `a_log` pulls every decay rate toward A = -1 over
+    /// long runs). Default OFF preserves the historical decay-everything
+    /// behavior bit-for-bit. Errs while a captured graph exists: the decay
+    /// coefficient is baked by value into the captured per-tensor AdamW
+    /// launches.
+    pub fn set_reference_no_decay(&mut self, on: bool) -> Result<(), String> {
+        if self.has_graph() {
+            return Err(
+                "set_reference_no_decay under a captured graph: the decay coefficient \
+                 is baked by value into the captured AdamW launches — drop_graph() \
+                 first, then toggle, then re-capture"
+                    .into(),
+            );
+        }
+        match &mut self.inner {
+            TrainerInner::F32(t) => t.adam.reference_no_decay = on,
+            TrainerInner::Mixed(t) => t.adam.reference_no_decay = on,
+        }
+        Ok(())
+    }
+
     /// Drop any captured step graph so `drop_graph -> set_lr ->
     /// capture_graph` is expressible. Subsequent [`Self::step`]s run
     /// eagerly until re-captured.

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -335,6 +335,53 @@ impl MambaTrainer {
         }
     }
 
+    /// Set the AdamW learning rate for subsequent EAGER steps. Errs while a
+    /// captured graph exists: the lr is baked BY VALUE into the captured
+    /// AdamW kernel at capture time, so a bare field write would be a
+    /// silent no-op under replay — the exact silent-wrong class this
+    /// crate's history punishes. Call [`Self::drop_graph`] first, then
+    /// `set_lr`, then re-[`Self::capture_graph`] if graph stepping is
+    /// still wanted.
+    pub fn set_lr(&mut self, lr: f32) -> Result<(), String> {
+        if !lr.is_finite() || lr <= 0.0 {
+            return Err(format!("set_lr: invalid learning rate {lr}"));
+        }
+        if self.has_graph() {
+            return Err(
+                "set_lr under a captured graph: the lr is baked by value into the \
+                 captured AdamW kernel and a field write would silently not apply — \
+                 drop_graph() first, then set_lr, then re-capture"
+                    .into(),
+            );
+        }
+        match &mut self.inner {
+            TrainerInner::F32(t) => t.adam.lr = lr,
+            TrainerInner::Mixed(t) => t.adam.lr = lr,
+        }
+        Ok(())
+    }
+
+    /// Current AdamW learning rate.
+    pub fn lr(&self) -> f32 {
+        match &self.inner {
+            TrainerInner::F32(t) => t.adam.lr,
+            TrainerInner::Mixed(t) => t.adam.lr,
+        }
+    }
+
+    /// Drop any captured step graph so `drop_graph -> set_lr ->
+    /// capture_graph` is expressible. Subsequent [`Self::step`]s run
+    /// eagerly until re-captured.
+    pub fn drop_graph(&mut self) {
+        match &mut self.inner {
+            TrainerInner::F32(t) => t.graph = None,
+            TrainerInner::Mixed(t) => {
+                t.graph = None;
+                t.graph_f16 = None;
+            }
+        }
+    }
+
     /// Reset the recurrent SSM + conv states to zero. Call between
     /// independent training sequences (e.g. on episode boundary in RL
     /// or document boundary in LM).

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -162,6 +162,63 @@ impl StepMetrics {
     }
 }
 
+/// Options for [`MambaTrainer::backward_step`].
+///
+/// `#[non_exhaustive]` + `with_*` builders: cross-crate struct literals are
+/// blocked on purpose so future fields stay semver-minor. The derived
+/// `Default` is the safe fused-step behavior (zero the arena, run backward,
+/// run the full optimizer tail).
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BackwardOpts {
+    /// `Some(c)`: after backward (and, for f16, after unscale) scale the
+    /// gradients by `min(1, c / (||g||_2 + 1e-6))` before AdamW —
+    /// `torch.nn.utils.clip_grad_norm_` semantics. NOT WIRED YET: returns
+    /// an error until the deterministic `grad_clip` kernel lands (the next
+    /// step of this branch).
+    pub clip_max_norm: Option<f32>,
+    /// `true`: accumulate only — the gradient arena is NOT zeroed by the
+    /// next `backward_step`, Adam does not advance, and AdamW /
+    /// master→compute sync / the `a_neg` refresh are all skipped. Loss
+    /// averaging stays caller-side (scale `d_temporal` by `1/n_micro`).
+    /// Unsupported for f16 (the loss-scale freeze window across
+    /// micro-batches has no defined semantics).
+    pub accumulate_only: bool,
+}
+
+impl BackwardOpts {
+    /// Request global-norm gradient clipping at `c`.
+    pub fn with_clip_max_norm(mut self, c: f32) -> Self {
+        self.clip_max_norm = Some(c);
+        self
+    }
+
+    /// Toggle accumulate-only mode (see the field docs).
+    pub fn with_accumulate_only(mut self, on: bool) -> Self {
+        self.accumulate_only = on;
+        self
+    }
+}
+
+/// Metrics returned by [`MambaTrainer::backward_step`].
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct BackwardMetrics {
+    /// Adam step counter AFTER this call; unchanged on an accumulate-only
+    /// call and on an f16 overflow-skipped step.
+    pub step: u64,
+    /// Whether AdamW actually ran (false on accumulate-only / f16 overflow).
+    pub optimizer_stepped: bool,
+    /// Pre-clip, post-unscale global gradient L2 norm; `Some` iff clipping
+    /// was requested. Deliberately never added to [`StepMetrics`] — the
+    /// fused step must not grow a hidden device sync.
+    pub grad_norm: Option<f32>,
+    /// `Some(scale)` when the f16 loss scaler is active.
+    pub loss_scale: Option<f32>,
+    /// `Some(true)` when the f16 scaler detected inf/nan and skipped AdamW.
+    pub overflow_skipped: Option<bool>,
+}
+
 /// Internal precision-dispatch enum. Hidden behind [`MambaTrainer`] so the
 /// public API is a single struct with a single set of method names — caller
 /// never matches `F32`/`Mixed` directly. Mirrors `inference::BackboneEngine`.
@@ -308,6 +365,42 @@ impl MambaTrainer {
         }
     }
 
+    /// Eager forward half of the split step: runs the training forward and
+    /// writes the FULL `batch * seq_len * d_model` POST-norm_f temporal
+    /// output into caller-owned `temporal_out` — f32 on ALL dtypes
+    /// (bf16/f16 outputs are upcast on-device before download).
+    /// Stream-synchronized on return, so `temporal_out` is valid host data.
+    ///
+    /// Advances the recurrent conv/SSM state — call [`Self::reset_state`]
+    /// between independent sequences. Always runs the eager path, even when
+    /// a step graph is captured: the split exists so a caller-side loss can
+    /// run between forward and backward, which a captured whole-step graph
+    /// cannot express. The fused [`Self::step`] remains the
+    /// graph-capturable fast path and is byte-identical in numerics (both
+    /// compose the same eager bodies).
+    pub fn forward(&mut self, input: &[f32], temporal_out: &mut [f32]) -> Result<(), String> {
+        match &mut self.inner {
+            TrainerInner::F32(t) => t.forward_split(input, temporal_out),
+            TrainerInner::Mixed(t) => t.forward_split(input, temporal_out),
+        }
+    }
+
+    /// Backward + optimizer half of the split step. `d_temporal` is the
+    /// gradient w.r.t. the IMMEDIATELY PRECEDING [`Self::forward`]'s
+    /// temporal output (`batch * seq_len * d_model`, f32 — exactly the
+    /// tensor `temporal_out` held). Errs when no forward is pending (the
+    /// saved activations would be stale or missing). Always eager.
+    pub fn backward_step(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        match &mut self.inner {
+            TrainerInner::F32(t) => t.backward_split(d_temporal, opts),
+            TrainerInner::Mixed(t) => t.backward_split(d_temporal, opts),
+        }
+    }
+
     /// Download the f32 master weights to CPU for checkpointing. Always
     /// f32 regardless of the compute dtype — mixed-precision training
     /// keeps a separate master copy that the optimizer updates.
@@ -379,6 +472,21 @@ pub(crate) struct MambaTrainerMixed {
     // Upload buffers (stable pointers — reused every step).
     mamba_input: GpuBuffer,
     d_temporal: GpuBuffer,
+
+    /// Dedicated f32 staging for the split forward's readback: the typed
+    /// post-norm_f output (`scratch.temporal_typed`) is clobbered by the
+    /// backward's B0 pass, and `DtypedBuf::download_f32` heap-allocates a
+    /// full-size Vec per call — so `forward_split` upcasts into this
+    /// pre-allocated buffer and downloads from it.
+    temporal_f32: GpuBuffer,
+    /// True between a `forward_split` and the `backward_split` consuming its
+    /// saved activations (split-phase interlock).
+    split_forward_pending: bool,
+    /// True while an `accumulate_only` backward window is open: the next
+    /// backward must NOT zero the arena, and the fused `step()` must refuse
+    /// to run (its body zeroes the arena and would silently discard the
+    /// accumulated gradients).
+    grads_dirty: bool,
 
     // Lazily-populated CUDA Graph. None → eager path; Some → replayed.
     // Always None for f16 (loss-scaler overflow check requires CPU readback,
@@ -492,6 +600,7 @@ impl MambaTrainerMixed {
 
         let mamba_input = GpuBuffer::zeros(&ctx.stream, batch * seq_len * input_dim)?;
         let d_temporal = GpuBuffer::zeros(&ctx.stream, batch * seq_len * cfg.d_model)?;
+        let temporal_f32 = GpuBuffer::zeros(&ctx.stream, batch * seq_len * cfg.d_model)?;
         let grads = GpuMambaGrads::new(&ctx.stream, &cfg, input_dim)?;
 
         let adam = GpuAdamW::new(&ctx.stream, grads.flat.len())?
@@ -533,6 +642,9 @@ impl MambaTrainerMixed {
             a_neg_all,
             mamba_input,
             d_temporal,
+            temporal_f32,
+            split_forward_pending: false,
+            grads_dirty: false,
             graph: None,
             scaler,
             overflow_flag,
@@ -654,6 +766,14 @@ impl MambaTrainerMixed {
             self.d_temporal.len(),
             d_temporal.len()
         );
+        if self.grads_dirty {
+            return Err(
+                "step(): an accumulate_only backward window is open — close it with \
+                 backward_step(accumulate_only=false); the fused step zeroes the grad \
+                 arena and would silently discard the accumulated gradients"
+                    .into(),
+            );
+        }
 
         if matches!(self.dtype, WeightDtype::F16) {
             return self.step_f16(input, d_temporal);
@@ -686,6 +806,200 @@ impl MambaTrainerMixed {
         };
 
         Ok(StepMetrics::plain(step, replayed))
+    }
+
+    /// Split forward (see [`MambaTrainer::forward`]): eager forward, upcast
+    /// the typed post-norm_f output into the dedicated f32 staging buffer,
+    /// sync, download into `temporal_out`.
+    pub(crate) fn forward_split(
+        &mut self,
+        input: &[f32],
+        temporal_out: &mut [f32],
+    ) -> Result<(), String> {
+        assert_eq!(
+            input.len(),
+            self.mamba_input.len(),
+            "input shape mismatch: expected batch*seq_len*input_dim={}, got {}",
+            self.mamba_input.len(),
+            input.len(),
+        );
+        assert_eq!(
+            temporal_out.len(),
+            self.temporal_f32.len(),
+            "temporal_out shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.temporal_f32.len(),
+            temporal_out.len(),
+        );
+        self.mamba_input.upload(&self.ctx.stream, input)?;
+        self.eager_forward()?;
+        {
+            let dst = self.temporal_f32.cached_ptr();
+            let src = self.scratch.temporal_typed.cached_ptr();
+            let kernel = match self.scratch.temporal_typed.dtype() {
+                WeightDtype::Bf16 => &self.ctx.kernels.cast_bf16_to_f32,
+                WeightDtype::F16 => &self.ctx.kernels.cast_f16_to_f32,
+                WeightDtype::F32 => {
+                    return Err("forward_split: unexpected f32 temporal_typed in Mixed".into());
+                }
+            };
+            let n = self.temporal_f32.len() as i32;
+            let mut b = self.ctx.stream.launch_builder(kernel);
+            b.arg(&dst);
+            b.arg(&src);
+            b.arg(&n);
+            unsafe { b.launch(grid_1d(self.temporal_f32.len())) }
+                .map_err(|e| format!("forward_split: temporal upcast: {e:?}"))?;
+        }
+        self.ctx
+            .stream
+            .synchronize()
+            .map_err(|e| format!("forward_split sync: {e:?}"))?;
+        self.temporal_f32.download(&self.ctx.stream, temporal_out)?;
+        self.split_forward_pending = true;
+        Ok(())
+    }
+
+    /// Split backward + optimizer (see [`MambaTrainer::backward_step`]).
+    pub(crate) fn backward_split(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        if !self.split_forward_pending {
+            return Err(
+                "backward_step() without a pending forward() — the saved activations \
+                 are stale or missing; call forward() first"
+                    .into(),
+            );
+        }
+        if opts.clip_max_norm.is_some() {
+            return Err(
+                "clip_max_norm is not wired yet — the deterministic grad_clip kernel \
+                 lands in the next step of this branch"
+                    .into(),
+            );
+        }
+        assert_eq!(
+            d_temporal.len(),
+            self.d_temporal.len(),
+            "d_temporal shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.d_temporal.len(),
+            d_temporal.len(),
+        );
+
+        if matches!(self.dtype, WeightDtype::F16) {
+            if opts.accumulate_only {
+                return Err(
+                    "f16 + accumulate_only is unsupported: the loss-scale freeze window \
+                     across micro-batches has no defined semantics"
+                        .into(),
+                );
+            }
+            let m = self.backward_split_f16(d_temporal)?;
+            self.split_forward_pending = false;
+            return Ok(m);
+        }
+
+        self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
+        if !self.grads_dirty {
+            self.grads.zero(&self.ctx.stream)?;
+        }
+        self.eager_backward(false)?;
+        self.split_forward_pending = false;
+
+        if opts.accumulate_only {
+            self.grads_dirty = true;
+            Ok(BackwardMetrics {
+                step: self.adam.step,
+                optimizer_stepped: false,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        } else {
+            let (step, bc1, bc2) = self.adam.advance();
+            self.bias.write(&self.ctx.stream, bc1, bc2)?;
+            self.eager_optimize()?;
+            self.grads_dirty = false;
+            Ok(BackwardMetrics {
+                step,
+                optimizer_stepped: true,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        }
+    }
+
+    /// f16 split backward: mirrors the `step_f16` eager branch minus the
+    /// forward (GradScaler protocol — scale, backward, overflow check,
+    /// conditional unscale + optimize, scaler update, step rollback).
+    fn backward_split_f16(&mut self, d_temporal: &[f32]) -> Result<BackwardMetrics, String> {
+        let scale = self.scaler.as_ref().expect("f16 scaler").scale();
+        {
+            let dt_scaled = self.d_temporal_scaled.as_mut().expect("f16 dt_scaled");
+            dt_scaled.upload(&self.ctx.stream, d_temporal)?;
+            let n = d_temporal.len() as i32;
+            let mut builder = self
+                .ctx
+                .stream
+                .launch_builder(&self.ctx.kernels.scale_grads_f32);
+            builder.arg(dt_scaled.inner_mut());
+            builder.arg(&scale);
+            builder.arg(&n);
+            unsafe { builder.launch(grid_1d(d_temporal.len())) }
+                .map_err(|e| format!("scale d_temporal (f16 split): {e:?}"))?;
+        }
+        if let Some(ref mut u) = self.unscale_factor {
+            u.write(&self.ctx.stream, 1.0 / scale)?;
+        }
+        let prev_step = self.adam.step;
+        let (next_step, bc1, bc2) = self.adam.advance();
+        self.bias.write(&self.ctx.stream, bc1, bc2)?;
+        self.overflow_flag
+            .as_mut()
+            .expect("f16 overflow flag")
+            .zero(&self.ctx.stream)?;
+
+        self.grads.zero(&self.ctx.stream)?;
+        self.eager_backward(true)?;
+        check_inf_nan_gpu(
+            &self.ctx,
+            &self.ctx.kernels,
+            self.overflow_flag.as_mut().unwrap(),
+            &self.grads.flat,
+        )?;
+        let overflow = self
+            .overflow_flag
+            .as_ref()
+            .unwrap()
+            .read(&self.ctx.stream)?
+            != 0;
+        if !overflow {
+            let unscale = self.unscale_factor.as_ref().expect("unscale buf");
+            scale_grads_skip_gpu(
+                &self.ctx,
+                &self.ctx.kernels,
+                self.overflow_flag.as_mut().unwrap(),
+                &mut self.grads.flat,
+                unscale,
+            )?;
+            self.eager_optimize()?;
+        }
+        self.scaler.as_mut().expect("f16 scaler").update(overflow);
+        let final_step = if overflow {
+            self.adam.step = prev_step;
+            prev_step
+        } else {
+            next_step
+        };
+        Ok(BackwardMetrics {
+            step: final_step,
+            optimizer_stepped: !overflow,
+            grad_norm: None,
+            loss_scale: Some(scale),
+            overflow_skipped: Some(overflow),
+        })
     }
 
     /// f16 step (eager, no graph). Mirrors PyTorch GradScaler protocol:
@@ -1051,6 +1365,12 @@ pub(crate) struct MambaTrainerF32 {
     mamba_input: GpuBuffer,
     d_temporal: GpuBuffer,
     graph: Option<GpuMambaF32TrainingStepGraph>,
+    /// True between a `forward_split` and the `backward_split` consuming its
+    /// saved activations (split-phase interlock).
+    split_forward_pending: bool,
+    /// True while an `accumulate_only` backward window is open (see the
+    /// same-named field on `MambaTrainerMixed`).
+    grads_dirty: bool,
 }
 
 impl MambaTrainerF32 {
@@ -1144,6 +1464,8 @@ impl MambaTrainerF32 {
             mamba_input,
             d_temporal,
             graph: None,
+            split_forward_pending: false,
+            grads_dirty: false,
         })
     }
 
@@ -1204,6 +1526,14 @@ impl MambaTrainerF32 {
             self.d_temporal.len(),
             d_temporal.len(),
         );
+        if self.grads_dirty {
+            return Err(
+                "step(): an accumulate_only backward window is open — close it with \
+                 backward_step(accumulate_only=false); the fused step zeroes the grad \
+                 arena and would silently discard the accumulated gradients"
+                    .into(),
+            );
+        }
         self.mamba_input.upload(&self.ctx.stream, input)?;
         self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
 
@@ -1229,6 +1559,98 @@ impl MambaTrainerF32 {
         };
 
         Ok(StepMetrics::plain(step, replayed))
+    }
+
+    /// Split forward (see [`MambaTrainer::forward`]): eager forward into the
+    /// existing `self.temporal` device buffer, sync, download into
+    /// `temporal_out`. Zero new device allocation — the buffer already
+    /// exists and was previously write-only.
+    pub(crate) fn forward_split(
+        &mut self,
+        input: &[f32],
+        temporal_out: &mut [f32],
+    ) -> Result<(), String> {
+        assert_eq!(
+            input.len(),
+            self.mamba_input.len(),
+            "input shape mismatch: expected batch*seq_len*input_dim={}, got {}",
+            self.mamba_input.len(),
+            input.len(),
+        );
+        assert_eq!(
+            temporal_out.len(),
+            self.temporal.len(),
+            "temporal_out shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.temporal.len(),
+            temporal_out.len(),
+        );
+        self.mamba_input.upload(&self.ctx.stream, input)?;
+        self.eager_forward()?;
+        self.ctx
+            .stream
+            .synchronize()
+            .map_err(|e| format!("forward_split sync: {e:?}"))?;
+        self.temporal.download(&self.ctx.stream, temporal_out)?;
+        self.split_forward_pending = true;
+        Ok(())
+    }
+
+    /// Split backward + optimizer (see [`MambaTrainer::backward_step`]).
+    pub(crate) fn backward_split(
+        &mut self,
+        d_temporal: &[f32],
+        opts: BackwardOpts,
+    ) -> Result<BackwardMetrics, String> {
+        if !self.split_forward_pending {
+            return Err(
+                "backward_step() without a pending forward() — the saved activations \
+                 are stale or missing; call forward() first"
+                    .into(),
+            );
+        }
+        if opts.clip_max_norm.is_some() {
+            return Err(
+                "clip_max_norm is not wired yet — the deterministic grad_clip kernel \
+                 lands in the next step of this branch"
+                    .into(),
+            );
+        }
+        assert_eq!(
+            d_temporal.len(),
+            self.d_temporal.len(),
+            "d_temporal shape mismatch: expected batch*seq_len*d_model={}, got {}",
+            self.d_temporal.len(),
+            d_temporal.len(),
+        );
+        self.d_temporal.upload(&self.ctx.stream, d_temporal)?;
+        if !self.grads_dirty {
+            self.grads.zero(&self.ctx.stream)?;
+        }
+        self.eager_backward()?;
+        self.split_forward_pending = false;
+
+        if opts.accumulate_only {
+            self.grads_dirty = true;
+            Ok(BackwardMetrics {
+                step: self.adam.step,
+                optimizer_stepped: false,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        } else {
+            let (step, bc1, bc2) = self.adam.advance();
+            self.bias.write(&self.ctx.stream, bc1, bc2)?;
+            self.eager_optimize()?;
+            self.grads_dirty = false;
+            Ok(BackwardMetrics {
+                step,
+                optimizer_stepped: true,
+                grad_norm: None,
+                loss_scale: None,
+                overflow_skipped: None,
+            })
+        }
     }
 
     /// Eager forward body: run the training forward, writing the post-norm_f

--- a/src/mamba_ssm/gpu/trainer.rs
+++ b/src/mamba_ssm/gpu/trainer.rs
@@ -298,8 +298,9 @@ impl MambaTrainer {
 
     /// Run one training step on `(input, d_temporal)`. `input` must have
     /// length `batch * seq_len * input_dim`; `d_temporal` must have
-    /// length `batch * d_model` (gradient w.r.t. the final temporal
-    /// output). Returns [`StepMetrics`] with overflow / replay flags.
+    /// length `batch * seq_len * d_model` (gradient w.r.t. the FULL
+    /// post-norm_f temporal output sequence, not just the last position).
+    /// Returns [`StepMetrics`] with overflow / replay flags.
     pub fn step(&mut self, input: &[f32], d_temporal: &[f32]) -> Result<StepMetrics, String> {
         match &mut self.inner {
             TrainerInner::F32(t) => t.step(input, d_temporal),
@@ -1235,7 +1236,7 @@ impl MambaTrainerF32 {
         assert_eq!(
             d_temporal.len(),
             self.d_temporal.len(),
-            "d_temporal shape mismatch: expected batch*d_model={}, got {}",
+            "d_temporal shape mismatch: expected batch*seq_len*d_model={}, got {}",
             self.d_temporal.len(),
             d_temporal.len(),
         );

--- a/src/mamba_ssm/gpu/training_graph.rs
+++ b/src/mamba_ssm/gpu/training_graph.rs
@@ -240,7 +240,17 @@ impl GpuMambaTrainingStepGraph {
         // Same contract for the bi upcast scratch: when the batch-invariant
         // flag is on, the captured body routes its typed GEMMs through
         // `with_bi_upcast_scratch` — grow it to the step's maximum now.
-        ctx.presize_bi_upcast_scratch_for_train(cfg, batch, seq_len, train_w.dtype)?;
+        // input_dim-aware: a trainable patch-embed input_proj can exceed
+        // every backbone dim and would otherwise grow the scratch INSIDE
+        // capture.
+        let input_dim = mamba_input.len() / (batch * seq_len);
+        ctx.presize_bi_upcast_scratch_for_train_with_input(
+            cfg,
+            batch,
+            seq_len,
+            input_dim,
+            train_w.dtype,
+        )?;
 
         // Snapshot pointers BEFORE capture so we can stash them after the
         // helper consumes the &mut borrows.

--- a/src/module/backbone.rs
+++ b/src/module/backbone.rs
@@ -263,4 +263,41 @@ impl MambaBackbone {
     pub fn alloc_scratch(&self) -> MambaStepScratch {
         MambaStepScratch::new(&self.cfg)
     }
+
+    /// Allocate a full-sequence prefill scratch for sequences of `seq_len`.
+    pub fn alloc_prefill_scratch(
+        &self,
+        seq_len: usize,
+    ) -> crate::mamba_ssm::cpu::prefill::PrefillScratch {
+        let dims = crate::ops::dims::MambaDims::from_config(&self.cfg, seq_len, self.input_dim);
+        crate::mamba_ssm::cpu::prefill::PrefillScratch::new(&dims)
+    }
+
+    /// Full-sequence prefill: run `seq_len` inputs through the batched
+    /// SGEMM pipeline (orders of magnitude faster than the per-step
+    /// [`Self::forward_sequence`] loop), writing the post-norm_f output at
+    /// EVERY position and carrying the recurrent state so
+    /// [`Self::forward_step`] continues seamlessly (prefill-then-decode).
+    ///
+    /// `inputs`: `[seq_len * input_dim]`; `outputs`: `[seq_len * d_model]`.
+    pub fn forward_prefill(
+        &self,
+        inputs: &[f32],
+        outputs: &mut [f32],
+        state: &mut MambaState,
+        scratch: &mut crate::mamba_ssm::cpu::prefill::PrefillScratch,
+        seq_len: usize,
+        mode: crate::mamba_ssm::cpu::prefill::PrefillMode,
+    ) {
+        let dims = crate::ops::dims::MambaDims::from_config(&self.cfg, seq_len, self.input_dim);
+        crate::mamba_ssm::cpu::prefill::forward_mamba_backbone_prefill_mode(
+            outputs,
+            inputs,
+            &self.weights,
+            state,
+            scratch,
+            &dims,
+            mode,
+        );
+    }
 }

--- a/src/ops/blas.rs
+++ b/src/ops/blas.rs
@@ -148,6 +148,84 @@ pub fn sgemm_forward(
     }
 }
 
+/// [`sgemm_forward`] with the gemm crate's internal rayon parallelism —
+/// the prefill serving path's single-page latency lever (a lone sequence
+/// cannot amortize across a batch, so the GEMM itself must parallelize).
+/// Tile-local accumulation keeps results bit-identical to the serial path
+/// (verified by the prefill parallel-invariance test). The Accelerate
+/// branch already threads internally and the scalar fallback is not a
+/// serving configuration — both delegate to [`sgemm_forward`].
+pub fn sgemm_forward_par(
+    y: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    bias: Option<&[f32]>,
+    batch: usize,
+    n_in: usize,
+    n_out: usize,
+) {
+    #[cfg(all(
+        feature = "gemm-blas",
+        not(all(feature = "accelerate", target_os = "macos"))
+    ))]
+    {
+        assert!(
+            x.len() >= batch * n_in,
+            "sgemm_forward_par: x.len() {} < batch*n_in {}",
+            x.len(),
+            batch * n_in
+        );
+        assert!(
+            w.len() >= n_in * n_out,
+            "sgemm_forward_par: w.len() {} < n_in*n_out {}",
+            w.len(),
+            n_in * n_out
+        );
+        assert!(
+            y.len() >= batch * n_out,
+            "sgemm_forward_par: y.len() {} < batch*n_out {}",
+            y.len(),
+            batch * n_out
+        );
+        if let Some(b) = bias {
+            for row in 0..batch {
+                let off = row * n_out;
+                y[off..off + n_out].copy_from_slice(&b[..n_out]);
+            }
+        } else {
+            y[..batch * n_out].fill(0.0);
+        }
+        unsafe {
+            gemm::gemm(
+                batch,
+                n_out,
+                n_in,
+                y.as_mut_ptr(),
+                1,
+                n_out as isize,
+                true,
+                x.as_ptr(),
+                1,
+                n_in as isize,
+                w.as_ptr(),
+                1,
+                n_out as isize,
+                1.0,
+                1.0,
+                false,
+                false,
+                false,
+                gemm::Parallelism::Rayon(rayon::current_num_threads()),
+            );
+        }
+    }
+    #[cfg(not(all(
+        feature = "gemm-blas",
+        not(all(feature = "accelerate", target_os = "macos"))
+    )))]
+    sgemm_forward(y, x, w, bias, batch, n_in, n_out);
+}
+
 /// Single-sample matrix-vector forward: `y[N] = x[K] @ W[K,N] + bias[N]`.
 pub fn matvec_forward(
     y: &mut [f32],

--- a/tests/backward_mixed_parity.rs
+++ b/tests/backward_mixed_parity.rs
@@ -60,28 +60,16 @@ fn dims_for(cfg: &MambaConfig, batch: usize, seq_len: usize) -> GpuMambaDims {
     }
 }
 
-/// Build CPU weights for both paths. f32 uses `eye(d_model)` input_proj_w +
-/// zero bias so `temporal = mamba_input @ I + 0 = mamba_input`. Mixed uses
-/// empty (len_elems()==0) input_proj to trigger the D2D identity branch.
-/// Both paths see identical `acts.layers[0].residual = mamba_input`.
+/// Build CPU weights for both paths. Both carry the SAME real
+/// (non-identity) input projection: the mixed path implements the trainable
+/// input_proj natively, so the parity walk covers input_proj_w/b too. (The
+/// identity D2D branch keeps its own regression in backward_mixed_smoke.)
 fn build_weights(cfg: &MambaConfig, seed: u64) -> (MambaWeights, MambaWeights) {
     let mut w = MambaWeights::init(cfg, cfg.d_model, seed);
     for lw in w.layers.iter_mut() {
         lw.a_neg = lw.a_log.iter().map(|&v| -v.exp()).collect();
     }
-    let mut w_f32 = w.clone();
-    w_f32.input_proj_w = (0..cfg.d_model * cfg.d_model)
-        .map(|i| {
-            let r = i / cfg.d_model;
-            let c = i % cfg.d_model;
-            if r == c { 1.0 } else { 0.0 }
-        })
-        .collect();
-    w_f32.input_proj_b = vec![0.0; cfg.d_model];
-    let mut w_mixed = w;
-    w_mixed.input_proj_w.clear();
-    w_mixed.input_proj_b.clear();
-    (w_f32, w_mixed)
+    (w.clone(), w)
 }
 
 fn det_rand(n: usize, seed: u32) -> Vec<f32> {
@@ -393,12 +381,9 @@ fn backbone_grad_parity(dtype: WeightDtype) {
     let layout = grad_layout(&cfg, dims.mamba_input_dim);
     let mut off = 0usize;
     for (label, len) in layout {
-        let skip = label == "input_proj_w" || label == "input_proj_b";
-        if !skip {
-            let r = &grads_ref[off..off + len];
-            let t = &grads_typ[off..off + len];
-            assert_close(label, r, t, cos_min, norm_tol);
-        }
+        let r = &grads_ref[off..off + len];
+        let t = &grads_typ[off..off + len];
+        assert_close(label, r, t, cos_min, norm_tol);
         off += len;
     }
     assert_eq!(off, grads_ref.len());
@@ -457,12 +442,9 @@ fn backbone_grad_parity_multi_layer(dtype: WeightDtype) {
     let layout = grad_layout(&cfg, dims.mamba_input_dim);
     let mut off = 0usize;
     for (label, len) in layout {
-        let skip = label == "input_proj_w" || label == "input_proj_b";
-        if !skip {
-            let r = &grads_ref[off..off + len];
-            let t = &grads_typ[off..off + len];
-            assert_close(label, r, t, cos_min, norm_tol);
-        }
+        let r = &grads_ref[off..off + len];
+        let t = &grads_typ[off..off + len];
+        assert_close(label, r, t, cos_min, norm_tol);
         off += len;
     }
     assert_eq!(off, grads_ref.len());
@@ -555,7 +537,21 @@ fn scalar_loss_f64(t: &[f32]) -> f64 {
 fn finite_diff_f32_oracle() {
     let cfg = tiny_cfg();
     let dims = dims_for(&cfg, 1, 4);
-    let (w_f32, _) = build_weights(&cfg, 0xF1D1D1FF);
+    // This coarse f32 finite-diff (h=1e-2, 30% tolerance, top-5 probes) was
+    // calibrated against an identity input projection; a random projection
+    // shifts the loss landscape enough to push 1-2 probes past the noise
+    // floor. Keep its original eye/zero-bias environment — the REAL
+    // gradient certification (all tensors, rel<5e-3, incl. a rectangular
+    // input_proj) lives in tests/grad_oracle.rs.
+    let (mut w_f32, _) = build_weights(&cfg, 0xF1D1D1FF);
+    w_f32.input_proj_w = (0..cfg.d_model * cfg.d_model)
+        .map(|i| {
+            let r = i / cfg.d_model;
+            let c = i % cfg.d_model;
+            if r == c { 1.0 } else { 0.0 }
+        })
+        .collect();
+    w_f32.input_proj_b = vec![0.0; cfg.d_model];
 
     let bt = dims.bt();
     let mamba_input = det_rand(bt * dims.mamba_input_dim, 0xF1);

--- a/tests/grad_clip.rs
+++ b/tests/grad_clip.rs
@@ -1,0 +1,446 @@
+//! Global-norm gradient clipping contracts (BackwardOpts::clip_max_norm).
+//!
+//! - the reported norm matches an f64 CPU reference over the same gradients;
+//! - clip above threshold is a bit-exact no-op on the weight trajectory;
+//! - clip below threshold scales gradients exactly like pre-scaling
+//!   `d_temporal` by the clip coefficient (backward is linear in
+//!   `d_temporal`);
+//! - clip + accumulate_only is rejected;
+//! - f16: the norm is computed AFTER the unscale (a wrong order shows up as
+//!   a ~loss_scale-times inflated norm);
+//! - the norm is deterministic across identical runs.
+
+#![cfg(feature = "cuda")]
+
+use mamba_rs::config::MambaConfig;
+use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+use mamba_rs::mamba_ssm::gpu::trainer::{BackwardOpts, MambaTrainer, TrainSessionCfg};
+use mamba_rs::ops::dims::{MambaDims, MambaRecurrentState};
+use mamba_rs::train::backward::backward_mamba_backbone_batched;
+use mamba_rs::train::flat::MambaBackboneFlat;
+use mamba_rs::train::forward::forward_mamba_backbone_batched;
+use mamba_rs::train::scratch::{BackwardPhaseScratch, PhaseScratch};
+use mamba_rs::train::weights::{TrainMambaLayerWeights, TrainMambaWeights};
+use mamba_rs::weights::MambaWeights;
+
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn test_cfg() -> MambaConfig {
+    MambaConfig {
+        d_model: 32,
+        n_layers: 2,
+        d_state: 8,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    }
+}
+
+fn session(batch: usize, seq_len: usize, input_dim: usize) -> TrainSessionCfg {
+    TrainSessionCfg {
+        input_dim,
+        batch,
+        seq_len,
+        lr: 1e-3,
+        weight_decay: 1e-2,
+    }
+}
+
+fn train_weights_from(w: &MambaWeights) -> TrainMambaWeights {
+    TrainMambaWeights {
+        input_proj_w: w.input_proj_w.clone(),
+        input_proj_b: w.input_proj_b.clone(),
+        layers: w
+            .layers
+            .iter()
+            .map(|lw| TrainMambaLayerWeights {
+                norm_weight: lw.norm_weight.clone(),
+                in_proj_w: lw.in_proj_w.clone(),
+                conv1d_weight: lw.conv1d_weight.clone(),
+                conv1d_bias: lw.conv1d_bias.clone(),
+                x_proj_w: lw.x_proj_w.clone(),
+                dt_proj_w: lw.dt_proj_w.clone(),
+                dt_proj_b: lw.dt_proj_b.clone(),
+                a_log: lw.a_log.clone(),
+                d_param: lw.d_param.clone(),
+                out_proj_w: lw.out_proj_w.clone(),
+            })
+            .collect(),
+        norm_f_weight: w.norm_f_weight.clone(),
+    }
+}
+
+fn flat_weights(s: &MambaWeights) -> Vec<f32> {
+    let mut v = Vec::new();
+    v.extend_from_slice(&s.input_proj_w);
+    v.extend_from_slice(&s.input_proj_b);
+    for l in &s.layers {
+        v.extend_from_slice(&l.norm_weight);
+        v.extend_from_slice(&l.in_proj_w);
+        v.extend_from_slice(&l.conv1d_weight);
+        v.extend_from_slice(&l.conv1d_bias);
+        v.extend_from_slice(&l.x_proj_w);
+        v.extend_from_slice(&l.dt_proj_w);
+        v.extend_from_slice(&l.dt_proj_b);
+        v.extend_from_slice(&l.a_log);
+        v.extend_from_slice(&l.d_param);
+        v.extend_from_slice(&l.out_proj_w);
+    }
+    v.extend_from_slice(&s.norm_f_weight);
+    v
+}
+
+/// The reported grad norm must match an f64 norm of the CPU-computed
+/// gradients for the same weights / input / upstream gradient.
+#[test]
+fn clip_grad_norm_matches_cpu_reference() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let (batch, seq_len) = (1usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+    t.forward(&input, &mut out).expect("forward");
+    let m = t
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+        .expect("backward");
+    let gpu_norm = m.grad_norm.expect("grad_norm reported") as f64;
+
+    // CPU reference gradients.
+    let tw = train_weights_from(&w);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let di = cfg.d_inner();
+    let (ds, dc, nl) = (cfg.d_state, cfg.d_conv, cfg.n_layers);
+    let mut a_neg = vec![0.0f32; nl * di * ds];
+    for (l, lw) in w.layers.iter().enumerate() {
+        for i in 0..di * ds {
+            a_neg[l * di * ds + i] = -lw.a_log[i].exp();
+        }
+    }
+    let mut acts = MambaBackboneFlat::zeros(dims);
+    let mut fwd_scratch = PhaseScratch::zeros(&dims);
+    let mut conv = vec![0.0f32; nl * di * dc];
+    let mut ssm = vec![0.0f32; nl * di * ds];
+    let mut state = MambaRecurrentState {
+        conv: &mut conv,
+        ssm: &mut ssm,
+        a_neg: &a_neg,
+    };
+    let mut temporal = vec![0.0f32; seq_len * cfg.d_model];
+    forward_mamba_backbone_batched(
+        &mut temporal,
+        &mut acts,
+        &tw,
+        &input,
+        &mut state,
+        &mut fwd_scratch,
+        &dims,
+    );
+    let mut grads = TrainMambaWeights::zeros_from_dims(&dims);
+    let mut d_t = d_temporal.clone();
+    let mut bwd_scratch = BackwardPhaseScratch::zeros(&dims);
+    backward_mamba_backbone_batched(
+        &mut d_t,
+        &mut grads,
+        &acts,
+        &tw,
+        &a_neg,
+        &mut bwd_scratch,
+        &dims,
+    );
+    let mut flat: Vec<f32> = Vec::new();
+    flat.extend_from_slice(&grads.input_proj_w);
+    flat.extend_from_slice(&grads.input_proj_b);
+    for l in &grads.layers {
+        flat.extend_from_slice(&l.norm_weight);
+        flat.extend_from_slice(&l.in_proj_w);
+        flat.extend_from_slice(&l.conv1d_weight);
+        flat.extend_from_slice(&l.conv1d_bias);
+        flat.extend_from_slice(&l.x_proj_w);
+        flat.extend_from_slice(&l.dt_proj_w);
+        flat.extend_from_slice(&l.dt_proj_b);
+        flat.extend_from_slice(&l.a_log);
+        flat.extend_from_slice(&l.d_param);
+        flat.extend_from_slice(&l.out_proj_w);
+    }
+    flat.extend_from_slice(&grads.norm_f_weight);
+    let cpu_norm = flat
+        .iter()
+        .map(|&g| (g as f64) * (g as f64))
+        .sum::<f64>()
+        .sqrt();
+
+    let rel = (gpu_norm - cpu_norm).abs() / cpu_norm.max(1e-12);
+    assert!(
+        rel < 1e-3,
+        "grad_norm mismatch: gpu={gpu_norm} cpu={cpu_norm} rel={rel:e}"
+    );
+}
+
+/// clip far above the actual norm must not change the trajectory at all.
+#[test]
+fn clip_above_threshold_is_bit_identity() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (2usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+
+    let mut a = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer a");
+    a.forward(&input, &mut out).expect("fwd a");
+    a.backward_step(&d_temporal, BackwardOpts::default())
+        .expect("bwd a");
+
+    let mut b = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer b");
+    b.forward(&input, &mut out).expect("fwd b");
+    let m = b
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+        .expect("bwd b");
+    assert!(m.grad_norm.expect("norm").is_finite());
+
+    let sa = flat_weights(&a.snapshot_master().expect("a"));
+    let sb = flat_weights(&b.snapshot_master().expect("b"));
+    for (i, (x, y)) in sa.iter().zip(sb.iter()).enumerate() {
+        assert_eq!(
+            x.to_bits(),
+            y.to_bits(),
+            "above-threshold clip changed weight [{i}]: {x} vs {y}"
+        );
+    }
+}
+
+/// Backward is linear in d_temporal, so clipping at c must equal running
+/// with d_temporal pre-scaled by the clip coefficient.
+#[test]
+fn clip_below_threshold_equals_prescaled_d_temporal() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+
+    // Probe the unclipped norm.
+    let mut probe = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("probe");
+    probe.forward(&input, &mut out).expect("probe fwd");
+    let norm = probe
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+        .expect("probe bwd")
+        .grad_norm
+        .expect("norm") as f64;
+
+    let c = (norm / 2.0) as f32;
+    let coef = (c as f64 / (norm + 1e-6)) as f32;
+
+    let mut clipped = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("clipped");
+    clipped.forward(&input, &mut out).expect("clipped fwd");
+    let m = clipped
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(c))
+        .expect("clipped bwd");
+    let reported = m.grad_norm.expect("norm") as f64;
+    assert!(
+        (reported - norm).abs() / norm < 1e-6,
+        "reported norm must be PRE-clip: {reported} vs {norm}"
+    );
+
+    let scaled_dt: Vec<f32> = d_temporal.iter().map(|&v| v * coef).collect();
+    let mut prescaled = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("prescaled");
+    prescaled.forward(&input, &mut out).expect("prescaled fwd");
+    prescaled
+        .backward_step(&scaled_dt, BackwardOpts::default())
+        .expect("prescaled bwd");
+
+    let sa = flat_weights(&clipped.snapshot_master().expect("clipped"));
+    let sb = flat_weights(&prescaled.snapshot_master().expect("prescaled"));
+    let mut worst = 0.0f32;
+    for (x, y) in sa.iter().zip(sb.iter()) {
+        let d = (x - y).abs();
+        let denom = x.abs().max(y.abs()).max(1e-4);
+        worst = worst.max(d / denom);
+    }
+    assert!(
+        worst < 1e-5,
+        "clip-at-c diverges from prescaled d_temporal: max_rel={worst:e}"
+    );
+}
+
+#[test]
+fn clip_with_accumulate_errs() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+    t.forward(&input, &mut out).expect("forward");
+    assert!(
+        t.backward_step(
+            &d_temporal,
+            BackwardOpts::default()
+                .with_clip_max_norm(1.0)
+                .with_accumulate_only(true),
+        )
+        .is_err(),
+        "clip + accumulate_only must be rejected"
+    );
+}
+
+/// f16: the norm must be computed on UNSCALED gradients. A wrong order
+/// inflates the reported norm by ~loss_scale (65536x at init) — comparing
+/// against the bf16 trainer's norm (no loss scaler, same identity-input_proj
+/// branch) on identical weights catches that class. (The F32 engine cannot
+/// serve as the reference here: it has no identity-input_proj branch, and
+/// the Mixed engines accept ONLY identity.)
+#[test]
+fn f16_clip_norm_is_post_unscale() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let mut w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    w.input_proj_w.clear();
+    w.input_proj_b.clear();
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+
+    let mut f16 = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F16,
+    )
+    .expect("f16 trainer");
+    f16.forward(&input, &mut out).expect("f16 fwd");
+    let mf = f16
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+        .expect("f16 bwd");
+    assert_eq!(mf.overflow_skipped, Some(false));
+    let f16_norm = mf.grad_norm.expect("f16 norm") as f64;
+
+    let mut bf16 = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("bf16 trainer");
+    bf16.forward(&input, &mut out).expect("bf16 fwd");
+    let bf16_norm = bf16
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+        .expect("bf16 bwd")
+        .grad_norm
+        .expect("bf16 norm") as f64;
+
+    let ratio = f16_norm / bf16_norm;
+    assert!(
+        (0.5..2.0).contains(&ratio),
+        "f16 norm {f16_norm} vs bf16 norm {bf16_norm} (ratio {ratio}) — an inflated \
+         ratio means the norm was computed on loss-scaled gradients"
+    );
+}
+
+/// The norm is deterministic: identical runs report identical bits.
+#[test]
+fn clip_norm_is_deterministic() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (2usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+
+    let mut norms = Vec::new();
+    for _ in 0..2 {
+        let mut t = MambaTrainer::new_full(
+            0,
+            &w,
+            cfg,
+            session(batch, seq_len, input_dim),
+            WeightDtype::F32,
+        )
+        .expect("trainer");
+        t.forward(&input, &mut out).expect("fwd");
+        let m = t
+            .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1e9))
+            .expect("bwd");
+        norms.push(m.grad_norm.expect("norm"));
+    }
+    assert_eq!(
+        norms[0].to_bits(),
+        norms[1].to_bits(),
+        "grad norm must be bit-deterministic: {} vs {}",
+        norms[0],
+        norms[1]
+    );
+}

--- a/tests/grad_oracle.rs
+++ b/tests/grad_oracle.rs
@@ -1,0 +1,498 @@
+//! f64 shadow-forward gradient oracle for the Mamba-1 CPU training path.
+//!
+//! Every finite-difference test in the crate differences an f32 forward,
+//! whose accumulation noise floor (~1e-5) forces coarse steps (h=1e-2) and a
+//! 30% per-probe tolerance — good enough to catch sign/axis bugs, unable to
+//! certify a gradient formula, and unable to touch high-fan-out parameters
+//! at all. This oracle replaces that: a naive, un-optimized f64 reference
+//! forward (plain `f64::exp`, sequential recurrence) drops the differencing
+//! floor to ~1e-13, so a balanced central-difference step (h ~ 1e-5) yields
+//! ~1e-9 numeric accuracy. The crate's f32 ANALYTIC backward is then checked
+//! against the f64 numeric gradient at rel_err < 5e-3 per probed element —
+//! loose enough to absorb the f32-vs-f64 evaluation gap, tight enough that a
+//! wrong term or a missing chain-rule factor (which shows at >> 5e-3) cannot
+//! pass. Same philosophy as torch.autograd.gradcheck (f64 reference).
+//!
+//! Design pins:
+//! - The loss is a fixed random unit projection `L = <temporal, proj>` and
+//!   the analytic backward is seeded with `d_temporal = proj`, so analytic
+//!   and numeric measure the gradient of exactly the same scalar, and no
+//!   parameter sits in a flat/near-cancelling direction (the `sum(y^2)`
+//!   RMSNorm pathology).
+//! - Probes span the |grad| distribution of each tensor (max, quartiles,
+//!   minimum) — not only the top elements, which was an f32 noise-floor
+//!   workaround this oracle removes.
+//! - `a_log` gradients flow through the precomputed `a_neg = -exp(a_log)`;
+//!   the shadow recomputes `a_neg` from the perturbed `a_log` on every
+//!   probe, guarding the a_neg-refresh coupling at the math level.
+//! - Two configs: a rectangular `input_dim != d_model` (the vision patch
+//!   embed shape) and the square `input_dim == d_model` case.
+
+use mamba_rs::config::MambaConfig;
+use mamba_rs::ops::dims::{MambaDims, MambaRecurrentState};
+use mamba_rs::train::backward::backward_mamba_backbone_batched;
+use mamba_rs::train::flat::MambaBackboneFlat;
+use mamba_rs::train::forward::forward_mamba_backbone_batched;
+use mamba_rs::train::scratch::{BackwardPhaseScratch, PhaseScratch};
+use mamba_rs::train::weights::TrainMambaWeights;
+use mamba_rs::weights::MambaWeights;
+
+/// Deterministic xorshift pseudo-random fill (same idiom as the parity tests).
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn train_weights_from(w: &MambaWeights) -> TrainMambaWeights {
+    use mamba_rs::train::weights::TrainMambaLayerWeights;
+    TrainMambaWeights {
+        input_proj_w: w.input_proj_w.clone(),
+        input_proj_b: w.input_proj_b.clone(),
+        layers: w
+            .layers
+            .iter()
+            .map(|lw| TrainMambaLayerWeights {
+                norm_weight: lw.norm_weight.clone(),
+                in_proj_w: lw.in_proj_w.clone(),
+                conv1d_weight: lw.conv1d_weight.clone(),
+                conv1d_bias: lw.conv1d_bias.clone(),
+                x_proj_w: lw.x_proj_w.clone(),
+                dt_proj_w: lw.dt_proj_w.clone(),
+                dt_proj_b: lw.dt_proj_b.clone(),
+                a_log: lw.a_log.clone(),
+                d_param: lw.d_param.clone(),
+                out_proj_w: lw.out_proj_w.clone(),
+            })
+            .collect(),
+        norm_f_weight: w.norm_f_weight.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// f64 shadow weights + forward
+// ---------------------------------------------------------------------------
+
+struct F64Layer {
+    norm_weight: Vec<f64>,
+    in_proj_w: Vec<f64>,
+    conv1d_weight: Vec<f64>,
+    conv1d_bias: Vec<f64>,
+    x_proj_w: Vec<f64>,
+    dt_proj_w: Vec<f64>,
+    dt_proj_b: Vec<f64>,
+    a_log: Vec<f64>,
+    d_param: Vec<f64>,
+    out_proj_w: Vec<f64>,
+}
+
+struct F64Weights {
+    input_proj_w: Vec<f64>,
+    input_proj_b: Vec<f64>,
+    layers: Vec<F64Layer>,
+    norm_f_weight: Vec<f64>,
+}
+
+fn up(v: &[f32]) -> Vec<f64> {
+    v.iter().map(|&x| x as f64).collect()
+}
+
+impl F64Weights {
+    fn from_train(w: &TrainMambaWeights) -> Self {
+        Self {
+            input_proj_w: up(&w.input_proj_w),
+            input_proj_b: up(&w.input_proj_b),
+            layers: w
+                .layers
+                .iter()
+                .map(|l| F64Layer {
+                    norm_weight: up(&l.norm_weight),
+                    in_proj_w: up(&l.in_proj_w),
+                    conv1d_weight: up(&l.conv1d_weight),
+                    conv1d_bias: up(&l.conv1d_bias),
+                    x_proj_w: up(&l.x_proj_w),
+                    dt_proj_w: up(&l.dt_proj_w),
+                    dt_proj_b: up(&l.dt_proj_b),
+                    a_log: up(&l.a_log),
+                    d_param: up(&l.d_param),
+                    out_proj_w: up(&l.out_proj_w),
+                })
+                .collect(),
+            norm_f_weight: up(&w.norm_f_weight),
+        }
+    }
+
+    /// Mutable access to one tensor by (name, layer). Layer-scoped names use
+    /// `Some(idx)`; backbone-global tensors use `None`.
+    fn tensor_mut(&mut self, name: &str, layer: Option<usize>) -> &mut Vec<f64> {
+        match (name, layer) {
+            ("input_proj_w", None) => &mut self.input_proj_w,
+            ("input_proj_b", None) => &mut self.input_proj_b,
+            ("norm_f_weight", None) => &mut self.norm_f_weight,
+            (n, Some(l)) => {
+                let lw = &mut self.layers[l];
+                match n {
+                    "norm_weight" => &mut lw.norm_weight,
+                    "in_proj_w" => &mut lw.in_proj_w,
+                    "conv1d_weight" => &mut lw.conv1d_weight,
+                    "conv1d_bias" => &mut lw.conv1d_bias,
+                    "x_proj_w" => &mut lw.x_proj_w,
+                    "dt_proj_w" => &mut lw.dt_proj_w,
+                    "dt_proj_b" => &mut lw.dt_proj_b,
+                    "a_log" => &mut lw.a_log,
+                    "d_param" => &mut lw.d_param,
+                    "out_proj_w" => &mut lw.out_proj_w,
+                    other => panic!("unknown layer tensor {other}"),
+                }
+            }
+            (n, None) => panic!("unknown global tensor {n}"),
+        }
+    }
+}
+
+/// out[m,n] = x[m,k] @ w[k,n] (+ bias[n]) — mirrors `sgemm_forward` layout.
+fn gemm64(
+    out: &mut [f64],
+    x: &[f64],
+    w: &[f64],
+    bias: Option<&[f64]>,
+    m: usize,
+    k: usize,
+    n: usize,
+) {
+    for row in 0..m {
+        for col in 0..n {
+            let mut acc = bias.map_or(0.0, |b| b[col]);
+            for i in 0..k {
+                acc += x[row * k + i] * w[i * n + col];
+            }
+            out[row * n + col] = acc;
+        }
+    }
+}
+
+fn sigmoid64(x: f64) -> f64 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Naive f64 reference forward of the full M1 backbone. Mirrors
+/// `forward_mamba_backbone_batched` term for term (zero-initialized
+/// recurrent states, softplus threshold at 20.0, `a_neg` recomputed from
+/// `a_log`), with plain `f64::exp` everywhere.
+fn forward_f64(w: &F64Weights, input: &[f64], dims: &MambaDims) -> Vec<f64> {
+    let dm = dims.d_model;
+    let di = dims.d_inner;
+    let ds = dims.d_state;
+    let dc = dims.d_conv;
+    let dr = dims.dt_rank;
+    let xd = dims.xdbl_dim;
+    let mid = dims.mamba_input_dim;
+    let t_len = dims.seq_len;
+    let eps = dims.rms_norm_eps as f64;
+
+    // Input projection.
+    let mut temporal = vec![0.0f64; t_len * dm];
+    gemm64(
+        &mut temporal,
+        input,
+        &w.input_proj_w,
+        Some(&w.input_proj_b),
+        t_len,
+        mid,
+        dm,
+    );
+
+    for lw in &w.layers {
+        let a_neg: Vec<f64> = lw.a_log.iter().map(|&a| -a.exp()).collect();
+        let mut conv_state = vec![0.0f64; di * dc];
+        let mut ssm_state = vec![0.0f64; di * ds];
+
+        // F1: RMSNorm.
+        let residual = temporal.clone();
+        let mut post_norm = vec![0.0f64; t_len * dm];
+        for t in 0..t_len {
+            let src = &residual[t * dm..(t + 1) * dm];
+            let mean_sq = src.iter().map(|v| v * v).sum::<f64>() / dm as f64;
+            let inv_rms = 1.0 / (mean_sq + eps).sqrt();
+            for d in 0..dm {
+                post_norm[t * dm + d] = src[d] * inv_rms * lw.norm_weight[d];
+            }
+        }
+
+        // F2/F3: in_proj + split + gate SiLU.
+        let mut proj = vec![0.0f64; t_len * 2 * di];
+        gemm64(
+            &mut proj,
+            &post_norm,
+            &lw.in_proj_w,
+            None,
+            t_len,
+            dm,
+            2 * di,
+        );
+
+        // F4a: conv1d shift register + fused SiLU.
+        let mut u_all = vec![0.0f64; t_len * di];
+        for t in 0..t_len {
+            for d in 0..di {
+                let base = d * dc;
+                for k in 0..dc - 1 {
+                    conv_state[base + k] = conv_state[base + k + 1];
+                }
+                conv_state[base + dc - 1] = proj[t * 2 * di + d];
+                let mut val = lw.conv1d_bias[d];
+                for k in 0..dc {
+                    val += conv_state[base + k] * lw.conv1d_weight[base + k];
+                }
+                u_all[t * di + d] = val * sigmoid64(val);
+            }
+        }
+
+        // F4b/F4c: x_proj, dt_proj + softplus.
+        let mut xdbl = vec![0.0f64; t_len * xd];
+        gemm64(&mut xdbl, &u_all, &lw.x_proj_w, None, t_len, di, xd);
+        let mut dt_in = vec![0.0f64; t_len * dr];
+        for t in 0..t_len {
+            dt_in[t * dr..(t + 1) * dr].copy_from_slice(&xdbl[t * xd..t * xd + dr]);
+        }
+        let mut delta = vec![0.0f64; t_len * di];
+        gemm64(
+            &mut delta,
+            &dt_in,
+            &lw.dt_proj_w,
+            Some(&lw.dt_proj_b),
+            t_len,
+            dr,
+            di,
+        );
+        for v in delta.iter_mut() {
+            if *v <= 20.0 {
+                *v = v.exp().ln_1p();
+            }
+        }
+
+        // F4d/F4e: SSM recurrence + gating; F5: out_proj; F6: residual.
+        let mut gated = vec![0.0f64; t_len * di];
+        for t in 0..t_len {
+            for d in 0..di {
+                let delta_d = delta[t * di + d];
+                let u_d = u_all[t * di + d];
+                let a_base = d * ds;
+                let mut y_d = 0.0f64;
+                for n in 0..ds {
+                    let idx = a_base + n;
+                    let b_n = xdbl[t * xd + dr + n];
+                    let c_n = xdbl[t * xd + dr + ds + n];
+                    let da = (delta_d * a_neg[idx]).exp();
+                    ssm_state[idx] = da * ssm_state[idx] + delta_d * u_d * b_n;
+                    y_d += ssm_state[idx] * c_n;
+                }
+                y_d += lw.d_param[d] * u_d;
+                let g = proj[t * 2 * di + di + d];
+                gated[t * di + d] = y_d * (g * sigmoid64(g));
+            }
+        }
+        let mut out = vec![0.0f64; t_len * dm];
+        gemm64(&mut out, &gated, &lw.out_proj_w, None, t_len, di, dm);
+        for i in 0..t_len * dm {
+            temporal[i] = residual[i] + out[i];
+        }
+    }
+
+    // norm_f.
+    for t in 0..t_len {
+        let off = t * dm;
+        let mean_sq = temporal[off..off + dm].iter().map(|v| v * v).sum::<f64>() / dm as f64;
+        let inv_rms = 1.0 / (mean_sq + eps).sqrt();
+        for d in 0..dm {
+            temporal[off + d] *= inv_rms * w.norm_f_weight[d];
+        }
+    }
+    temporal
+}
+
+// ---------------------------------------------------------------------------
+// The oracle harness
+// ---------------------------------------------------------------------------
+
+/// Pick probe indices spanning the |grad| distribution: max, quartiles, min.
+fn probe_indices(grad: &[f32]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..grad.len()).collect();
+    order.sort_by(|&a, &b| grad[a].abs().partial_cmp(&grad[b].abs()).unwrap());
+    let n = order.len();
+    let picks = [n - 1, (3 * n) / 4, n / 2, n / 4, 0];
+    let mut out: Vec<usize> = picks.iter().map(|&p| order[p.min(n - 1)]).collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn run_oracle(input_dim: usize) {
+    let cfg = MambaConfig {
+        d_model: 32,
+        n_layers: 2,
+        d_state: 8,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    };
+    let seq_len = 4;
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let dm = cfg.d_model;
+    let di = cfg.d_inner();
+    let ds = cfg.d_state;
+    let dc = cfg.d_conv;
+    let nl = cfg.n_layers;
+
+    let weights = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let tw = train_weights_from(&weights);
+    let input = det(seq_len * input_dim, 0xAA, 0.5);
+
+    // Fixed unit-norm random projection: the loss is L = <temporal, proj>,
+    // and the analytic backward is seeded with d_temporal = proj so both
+    // sides measure the gradient of the same scalar.
+    let mut proj = det(seq_len * dm, 0xBB, 1.0);
+    let norm = proj.iter().map(|&v| (v as f64).powi(2)).sum::<f64>().sqrt() as f32;
+    for v in proj.iter_mut() {
+        *v /= norm;
+    }
+
+    // Analytic side: f32 forward + backward through the crate path.
+    let mut a_neg_flat = vec![0.0f32; nl * di * ds];
+    for (l, lw) in tw.layers.iter().enumerate() {
+        for i in 0..di * ds {
+            a_neg_flat[l * di * ds + i] = -lw.a_log[i].exp();
+        }
+    }
+    let mut acts = MambaBackboneFlat::zeros(dims);
+    let mut fwd_scratch = PhaseScratch::zeros(&dims);
+    let mut conv_state = vec![0.0f32; nl * di * dc];
+    let mut ssm_state = vec![0.0f32; nl * di * ds];
+    let mut state = MambaRecurrentState {
+        conv: &mut conv_state,
+        ssm: &mut ssm_state,
+        a_neg: &a_neg_flat,
+    };
+    let mut temporal = vec![0.0f32; seq_len * dm];
+    forward_mamba_backbone_batched(
+        &mut temporal,
+        &mut acts,
+        &tw,
+        &input,
+        &mut state,
+        &mut fwd_scratch,
+        &dims,
+    );
+
+    let mut grads = TrainMambaWeights::zeros_from_dims(&dims);
+    let mut d_temporal = proj.clone();
+    let mut bwd_scratch = BackwardPhaseScratch::zeros(&dims);
+    backward_mamba_backbone_batched(
+        &mut d_temporal,
+        &mut grads,
+        &acts,
+        &tw,
+        &a_neg_flat,
+        &mut bwd_scratch,
+        &dims,
+    );
+
+    // Cross-check the f64 shadow forward itself against the f32 forward
+    // before trusting its finite differences.
+    let mut w64 = F64Weights::from_train(&tw);
+    let input64 = up(&input);
+    let base64 = forward_f64(&w64, &input64, &dims);
+    // Tolerance: the f32 path uses fast_exp (~1.4 ULP Cephes) and f32
+    // accumulation through the recurrence; ~1e-3 relative with a small
+    // absolute floor is the honest f32-vs-f64 evaluation gap, far below
+    // anything a formula error would produce.
+    for (i, (&a, &b)) in temporal.iter().zip(base64.iter()).enumerate() {
+        let diff = (a as f64 - b).abs();
+        let denom = (a as f64).abs().max(b.abs()).max(1e-2);
+        assert!(
+            diff / denom < 1e-3,
+            "f64 shadow forward diverges from f32 forward at {i}: {a} vs {b}"
+        );
+    }
+
+    let proj64 = up(&proj);
+    let loss = |temporal64: &[f64]| -> f64 {
+        temporal64
+            .iter()
+            .zip(proj64.iter())
+            .map(|(&t, &p)| t * p)
+            .sum()
+    };
+
+    let h = 1e-5f64;
+    // (name, layer, analytic grad slice)
+    let mut checks: Vec<(&str, Option<usize>, &[f32])> = vec![
+        ("input_proj_w", None, &grads.input_proj_w),
+        ("input_proj_b", None, &grads.input_proj_b),
+        ("norm_f_weight", None, &grads.norm_f_weight),
+    ];
+    for (l, lg) in grads.layers.iter().enumerate() {
+        checks.extend([
+            ("norm_weight", Some(l), lg.norm_weight.as_slice()),
+            ("in_proj_w", Some(l), lg.in_proj_w.as_slice()),
+            ("conv1d_weight", Some(l), lg.conv1d_weight.as_slice()),
+            ("conv1d_bias", Some(l), lg.conv1d_bias.as_slice()),
+            ("x_proj_w", Some(l), lg.x_proj_w.as_slice()),
+            ("dt_proj_w", Some(l), lg.dt_proj_w.as_slice()),
+            ("dt_proj_b", Some(l), lg.dt_proj_b.as_slice()),
+            ("a_log", Some(l), lg.a_log.as_slice()),
+            ("d_param", Some(l), lg.d_param.as_slice()),
+            ("out_proj_w", Some(l), lg.out_proj_w.as_slice()),
+        ]);
+    }
+
+    let mut probed = 0usize;
+    for (name, layer, analytic) in checks {
+        for idx in probe_indices(analytic) {
+            let a = analytic[idx] as f64;
+            let field = w64.tensor_mut(name, layer);
+            let orig = field[idx];
+            field[idx] = orig + h;
+            let lp = loss(&forward_f64(&w64, &input64, &dims));
+            w64.tensor_mut(name, layer)[idx] = orig - h;
+            let lm = loss(&forward_f64(&w64, &input64, &dims));
+            w64.tensor_mut(name, layer)[idx] = orig;
+            let numeric = (lp - lm) / (2.0 * h);
+
+            let denom = a.abs().max(numeric.abs());
+            if denom < 1e-6 {
+                // Zero-gradient probe: both sides must agree it is zero.
+                continue;
+            }
+            let rel = (a - numeric).abs() / denom;
+            assert!(
+                rel < 5e-3,
+                "{name}{} [{idx}]: analytic {a:e} vs f64 numeric {numeric:e} (rel {rel:e})",
+                layer.map_or(String::new(), |l| format!(" L{l}"))
+            );
+            probed += 1;
+        }
+    }
+    // The harness must actually have exercised the parameter space; a probe
+    // count collapse means the picker or the gradients degenerated.
+    assert!(probed > 60, "only {probed} non-degenerate probes ran");
+}
+
+/// Rectangular input_proj — the vision patch-embed shape (input_dim != d_model).
+#[test]
+fn m1_gradients_match_f64_oracle_rect_input() {
+    run_oracle(20);
+}
+
+/// Square input_proj — regression against the existing parity-test shape.
+#[test]
+fn m1_gradients_match_f64_oracle_square_input() {
+    run_oracle(32);
+}

--- a/tests/matvec_probe.rs
+++ b/tests/matvec_probe.rs
@@ -1,0 +1,66 @@
+//! Bisection probe: the batch-invariant matvec route of
+//! gpu_gemm_typed_forward_raw at the trainable-input_proj shapes.
+
+#![cfg(feature = "cuda")]
+
+use mamba_rs::mamba_ssm::gpu::blas::{TypedPtr, gpu_gemm_typed_forward_raw};
+use mamba_rs::mamba_ssm::gpu::buffers::{DtypedBuf, GpuBuffer};
+use mamba_rs::mamba_ssm::gpu::context::GpuCtx;
+use mamba_rs::mamba_ssm::gpu::device::GpuDevice;
+use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+
+fn probe(ctx: &GpuCtx, m: usize, k: usize, n: usize) -> Result<(), String> {
+    let dt = WeightDtype::Bf16;
+    let x = DtypedBuf::zeros(&ctx.stream, m * k, dt)?;
+    let w = DtypedBuf::zeros(&ctx.stream, k * n, dt)?;
+    let c = DtypedBuf::zeros(&ctx.stream, m * n, dt)?;
+    let bias = GpuBuffer::zeros(&ctx.stream, n)?;
+    gpu_gemm_typed_forward_raw(
+        ctx,
+        TypedPtr {
+            ptr: c.cached_ptr(),
+            dtype: dt,
+        },
+        TypedPtr {
+            ptr: x.cached_ptr(),
+            dtype: dt,
+        },
+        TypedPtr {
+            ptr: w.cached_ptr(),
+            dtype: dt,
+        },
+        Some(bias.cached_ptr()),
+        (m, k, n),
+    )?;
+    ctx.stream
+        .synchronize()
+        .map_err(|e| format!("sync after ({m},{k},{n}): {e:?}"))
+}
+
+fn probe_one(m: usize, k: usize, n: usize) {
+    let dev = GpuDevice::new(0).expect("dev");
+    let ctx = GpuCtx::new(&dev).expect("ctx");
+    ctx.set_batch_invariant(true);
+    probe(&ctx, m, k, n).unwrap_or_else(|e| panic!("shape ({m},{k},{n}): {e}"));
+}
+
+#[test]
+fn bi_matvec_k20() {
+    probe_one(4, 20, 32);
+}
+#[test]
+fn bi_matvec_k200() {
+    probe_one(4, 200, 32);
+}
+#[test]
+fn bi_matvec_k192() {
+    probe_one(4, 192, 32);
+}
+#[test]
+fn bi_matvec_k64() {
+    probe_one(4, 64, 32);
+}
+#[test]
+fn bi_matvec_k768() {
+    probe_one(4, 768, 32);
+}

--- a/tests/memory_footprint.rs
+++ b/tests/memory_footprint.rs
@@ -1,0 +1,63 @@
+//! Classifier-shape VRAM footprint probe (manual: --ignored).
+//!
+//! Constructs the bf16 trainer at the doc-101 classifier center shape
+//! (d_model=384 x 24 layers, d_state=16, T=4617, input_dim=1024 = 32x32
+//! grayscale patches, trainable input_proj) across micro-batch sizes and
+//! reports nvidia-smi memory after construction and after one step.
+//! Settles the "B=4 fits 32 GB?" question empirically.
+
+#![cfg(feature = "cuda")]
+
+use mamba_rs::config::MambaConfig;
+use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+use mamba_rs::mamba_ssm::gpu::trainer::{MambaTrainer, TrainSessionCfg};
+use mamba_rs::weights::MambaWeights;
+
+fn vram_used_mb() -> String {
+    std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=memory.used", "--format=csv,noheader,nounits"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|_| "?".into())
+}
+
+#[test]
+#[ignore]
+fn classifier_shape_memory_footprint() {
+    let cfg = MambaConfig {
+        d_model: 384,
+        n_layers: 24,
+        d_state: 16,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    };
+    let input_dim = 1024usize; // 32x32 grayscale patch
+    let seq_len = 4617usize;
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+
+    for batch in [1usize, 2, 4] {
+        eprintln!("=== batch {batch}: baseline {} MiB", vram_used_mb());
+        let session = TrainSessionCfg {
+            input_dim,
+            batch,
+            seq_len,
+            lr: 5e-4,
+            weight_decay: 0.05,
+        };
+        match MambaTrainer::new_full(0, &w, cfg, session, WeightDtype::Bf16) {
+            Ok(mut t) => {
+                eprintln!("    constructed: {} MiB", vram_used_mb());
+                let input = vec![0.01f32; batch * seq_len * input_dim];
+                let d_temporal = vec![0.001f32; batch * seq_len * cfg.d_model];
+                match t.step(&input, &d_temporal) {
+                    Ok(_) => eprintln!("    after step: {} MiB — B{batch} FITS", vram_used_mb()),
+                    Err(e) => eprintln!("    step FAILED at B{batch}: {e}"),
+                }
+            }
+            Err(e) => eprintln!("    construction FAILED at B{batch}: {e}"),
+        }
+        // Trainer dropped here — next iteration starts clean.
+    }
+}

--- a/tests/prefill.rs
+++ b/tests/prefill.rs
@@ -1,0 +1,366 @@
+//! Full-sequence CPU prefill contracts.
+//!
+//! - bitwise anchor vs the training forward (same GEMMs, same fast_exp,
+//!   same per-element chains);
+//! - Parallel == Single bitwise (channel-independent phases, tile-local
+//!   GEMM accumulation);
+//! - prefill-then-decode handoff into the per-step inference path;
+//! - identity input_proj branch == explicit eye projection, bitwise;
+//! - batch helper == sequential prefills, bitwise.
+
+use mamba_rs::config::MambaConfig;
+use mamba_rs::inference::{
+    PrefillMode, PrefillScratch, forward_mamba_backbone_prefill,
+    forward_mamba_backbone_prefill_mode, prefill_batch,
+};
+use mamba_rs::module::MambaBackbone;
+use mamba_rs::ops::dims::{MambaDims, MambaRecurrentState};
+use mamba_rs::state::MambaState;
+use mamba_rs::train::flat::MambaBackboneFlat;
+use mamba_rs::train::forward::forward_mamba_backbone_batched;
+use mamba_rs::train::scratch::PhaseScratch;
+use mamba_rs::train::weights::{TrainMambaLayerWeights, TrainMambaWeights};
+use mamba_rs::weights::MambaWeights;
+
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn test_cfg() -> MambaConfig {
+    MambaConfig {
+        d_model: 32,
+        n_layers: 2,
+        d_state: 8,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    }
+}
+
+fn init_weights(cfg: &MambaConfig, input_dim: usize, seed: u64) -> MambaWeights {
+    let mut w = MambaWeights::init(cfg, input_dim, seed);
+    for lw in w.layers.iter_mut() {
+        lw.a_neg = lw.a_log.iter().map(|&v| -v.exp()).collect();
+    }
+    w
+}
+
+fn train_weights_from(w: &MambaWeights) -> TrainMambaWeights {
+    TrainMambaWeights {
+        input_proj_w: w.input_proj_w.clone(),
+        input_proj_b: w.input_proj_b.clone(),
+        layers: w
+            .layers
+            .iter()
+            .map(|lw| TrainMambaLayerWeights {
+                norm_weight: lw.norm_weight.clone(),
+                in_proj_w: lw.in_proj_w.clone(),
+                conv1d_weight: lw.conv1d_weight.clone(),
+                conv1d_bias: lw.conv1d_bias.clone(),
+                x_proj_w: lw.x_proj_w.clone(),
+                dt_proj_w: lw.dt_proj_w.clone(),
+                dt_proj_b: lw.dt_proj_b.clone(),
+                a_log: lw.a_log.clone(),
+                d_param: lw.d_param.clone(),
+                out_proj_w: lw.out_proj_w.clone(),
+            })
+            .collect(),
+        norm_f_weight: w.norm_f_weight.clone(),
+    }
+}
+
+fn assert_bits(label: &str, a: &[f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len(), "{label}: length");
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        assert_eq!(x.to_bits(), y.to_bits(), "{label}[{i}]: {x} vs {y}");
+    }
+}
+
+/// Prefill (zero state) must reproduce the training forward bit-for-bit.
+#[test]
+fn prefill_matches_training_forward_bitwise() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 8usize;
+    let w = init_weights(&cfg, input_dim, 0xC0FFEE);
+    let input = det(seq_len * input_dim, 0xAA, 0.05);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let di = cfg.d_inner();
+    let (ds, dc, nl) = (cfg.d_state, cfg.d_conv, cfg.n_layers);
+
+    // Training forward.
+    let tw = train_weights_from(&w);
+    let mut a_neg = vec![0.0f32; nl * di * ds];
+    for (l, lw) in w.layers.iter().enumerate() {
+        a_neg[l * di * ds..(l + 1) * di * ds].copy_from_slice(&lw.a_neg);
+    }
+    let mut acts = MambaBackboneFlat::zeros(dims);
+    let mut fwd_scratch = PhaseScratch::zeros(&dims);
+    let mut conv = vec![0.0f32; nl * di * dc];
+    let mut ssm = vec![0.0f32; nl * di * ds];
+    let mut tr_state = MambaRecurrentState {
+        conv: &mut conv,
+        ssm: &mut ssm,
+        a_neg: &a_neg,
+    };
+    let mut train_out = vec![0.0f32; seq_len * cfg.d_model];
+    forward_mamba_backbone_batched(
+        &mut train_out,
+        &mut acts,
+        &tw,
+        &input,
+        &mut tr_state,
+        &mut fwd_scratch,
+        &dims,
+    );
+
+    // Prefill.
+    let mut state = MambaState::zeros(nl, di, ds, dc);
+    let mut scratch = PrefillScratch::new(&dims);
+    let mut out = vec![0.0f32; seq_len * cfg.d_model];
+    forward_mamba_backbone_prefill(&mut out, &input, &w, &mut state, &mut scratch, &dims);
+
+    assert_bits("prefill vs training forward", &out, &train_out);
+}
+
+/// Parallel mode must be bit-equal to Single.
+#[test]
+fn prefill_parallel_bit_equals_single() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 16usize;
+    let w = init_weights(&cfg, input_dim, 0xC0FFEE);
+    let input = det(seq_len * input_dim, 0xAB, 0.05);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let (di, ds, dc, nl) = (cfg.d_inner(), cfg.d_state, cfg.d_conv, cfg.n_layers);
+
+    let run = |mode: PrefillMode| -> (Vec<f32>, MambaState) {
+        let mut state = MambaState::zeros(nl, di, ds, dc);
+        let mut scratch = PrefillScratch::new(&dims);
+        let mut out = vec![0.0f32; seq_len * cfg.d_model];
+        forward_mamba_backbone_prefill_mode(
+            &mut out,
+            &input,
+            &w,
+            &mut state,
+            &mut scratch,
+            &dims,
+            mode,
+        );
+        (out, state)
+    };
+    let (out_s, st_s) = run(PrefillMode::Single);
+    let (out_p, st_p) = run(PrefillMode::Parallel);
+    assert_bits("parallel vs single output", &out_p, &out_s);
+    for (l, (a, b)) in st_s.layers.iter().zip(st_p.layers.iter()).enumerate() {
+        assert_bits(&format!("L{l} conv_state"), &b.conv_state, &a.conv_state);
+        assert_bits(&format!("L{l} ssm_state"), &b.ssm_state, &a.ssm_state);
+    }
+}
+
+/// After prefilling T tokens, the per-step decode path must continue the
+/// sequence as if all T+1 tokens had gone through the step loop (tolerance:
+/// the step path uses matvec accumulation orders, prefill uses SGEMM).
+#[test]
+fn prefill_then_decode_handoff() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model; // backbone from_weights derives input_dim
+    let seq_len = 8usize;
+    let w = init_weights(&cfg, input_dim, 0xC0FFEE);
+    let backbone = MambaBackbone::from_weights(cfg, w.clone()).expect("backbone");
+    let inputs = det((seq_len + 1) * input_dim, 0xAC, 0.05);
+
+    // Reference: the pure step loop over T+1 tokens.
+    let mut ref_state = backbone.alloc_state();
+    let mut ref_scratch = backbone.alloc_scratch();
+    let mut ref_out = vec![0.0f32; (seq_len + 1) * cfg.d_model];
+    backbone.forward_sequence(
+        &inputs,
+        &mut ref_out,
+        &mut ref_state,
+        &mut ref_scratch,
+        seq_len + 1,
+    );
+
+    // Prefill T, then decode token T via the step path.
+    let mut state = backbone.alloc_state();
+    let mut prefill_scratch = backbone.alloc_prefill_scratch(seq_len);
+    let mut prefill_out = vec![0.0f32; seq_len * cfg.d_model];
+    backbone.forward_prefill(
+        &inputs[..seq_len * input_dim],
+        &mut prefill_out,
+        &mut state,
+        &mut prefill_scratch,
+        seq_len,
+        PrefillMode::Single,
+    );
+    let mut step_scratch = backbone.alloc_scratch();
+    let mut step_out = vec![0.0f32; cfg.d_model];
+    backbone.forward_step(
+        &inputs[seq_len * input_dim..],
+        &mut step_out,
+        &mut state,
+        &mut step_scratch,
+    );
+
+    let ref_last = &ref_out[seq_len * cfg.d_model..];
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    let mut worst = 0.0f32;
+    for (&a, &b) in step_out.iter().zip(ref_last.iter()) {
+        dot += a as f64 * b as f64;
+        na += (a as f64).powi(2);
+        nb += (b as f64).powi(2);
+        let d = (a - b).abs();
+        worst = worst.max(d / a.abs().max(b.abs()).max(1e-3));
+    }
+    let cos = dot / (na.sqrt() * nb.sqrt());
+    assert!(
+        cos > 0.9999 && worst < 1e-2,
+        "handoff decode diverges from the step loop: cos={cos} max_rel={worst}"
+    );
+}
+
+/// The identity branch must equal an explicit eye projection bit-for-bit
+/// (X @ I + 0 is exact in f32).
+#[test]
+fn prefill_identity_equals_eye_projection() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let seq_len = 8usize;
+    let mut w_eye = init_weights(&cfg, input_dim, 0xC0FFEE);
+    w_eye.input_proj_w = (0..cfg.d_model * cfg.d_model)
+        .map(|i| {
+            if i / cfg.d_model == i % cfg.d_model {
+                1.0
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    w_eye.input_proj_b = vec![0.0; cfg.d_model];
+    let mut w_id = w_eye.clone();
+    w_id.input_proj_w.clear();
+    w_id.input_proj_b.clear();
+
+    let input = det(seq_len * input_dim, 0xAD, 0.05);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let (di, ds, dc, nl) = (cfg.d_inner(), cfg.d_state, cfg.d_conv, cfg.n_layers);
+
+    let run = |w: &MambaWeights| -> Vec<f32> {
+        let mut state = MambaState::zeros(nl, di, ds, dc);
+        let mut scratch = PrefillScratch::new(&dims);
+        let mut out = vec![0.0f32; seq_len * cfg.d_model];
+        forward_mamba_backbone_prefill(&mut out, &input, w, &mut state, &mut scratch, &dims);
+        out
+    };
+    assert_bits("identity vs eye", &run(&w_id), &run(&w_eye));
+}
+
+/// The batch helper must equal per-sample sequential prefills bit-for-bit.
+#[test]
+fn prefill_batch_matches_sequential() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 8usize;
+    let b = 3usize;
+    let w = init_weights(&cfg, input_dim, 0xC0FFEE);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let (di, ds, dc, nl) = (cfg.d_inner(), cfg.d_state, cfg.d_conv, cfg.n_layers);
+    let inputs = det(b * seq_len * input_dim, 0xAE, 0.05);
+
+    // Sequential reference.
+    let mut seq_out = vec![0.0f32; b * seq_len * cfg.d_model];
+    for i in 0..b {
+        let mut state = MambaState::zeros(nl, di, ds, dc);
+        let mut scratch = PrefillScratch::new(&dims);
+        forward_mamba_backbone_prefill(
+            &mut seq_out[i * seq_len * cfg.d_model..(i + 1) * seq_len * cfg.d_model],
+            &inputs[i * seq_len * input_dim..(i + 1) * seq_len * input_dim],
+            &w,
+            &mut state,
+            &mut scratch,
+            &dims,
+        );
+    }
+
+    // Batch helper.
+    let mut states: Vec<MambaState> = (0..b).map(|_| MambaState::zeros(nl, di, ds, dc)).collect();
+    let mut scratches: Vec<PrefillScratch> = (0..b).map(|_| PrefillScratch::new(&dims)).collect();
+    let mut batch_out = vec![0.0f32; b * seq_len * cfg.d_model];
+    prefill_batch(
+        &mut batch_out,
+        &inputs,
+        &w,
+        &mut states,
+        &mut scratches,
+        &dims,
+    );
+
+    assert_bits("batch vs sequential", &batch_out, &seq_out);
+}
+
+/// Latency probe at the classifier center shape (manual: --ignored).
+/// Prints ms/page for Single and Parallel modes plus the per-step loop
+/// extrapolation — the first measured numbers for the doc-101 serve tier.
+#[test]
+#[ignore]
+fn prefill_bench_classifier_shape() {
+    let cfg = MambaConfig {
+        d_model: 384,
+        n_layers: 24,
+        d_state: 16,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    };
+    let input_dim = 1024usize;
+    let seq_len = 4617usize;
+    let w = init_weights(&cfg, input_dim, 0xC0FFEE);
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let (di, ds, dc, nl) = (cfg.d_inner(), cfg.d_state, cfg.d_conv, cfg.n_layers);
+    let input = det(seq_len * input_dim, 0xAF, 0.05);
+    let mut out = vec![0.0f32; seq_len * cfg.d_model];
+
+    for mode in [PrefillMode::Single, PrefillMode::Parallel] {
+        let mut state = MambaState::zeros(nl, di, ds, dc);
+        let mut scratch = PrefillScratch::new(&dims);
+        // Warm-up.
+        forward_mamba_backbone_prefill_mode(
+            &mut out,
+            &input,
+            &w,
+            &mut state,
+            &mut scratch,
+            &dims,
+            mode,
+        );
+        let reps = 3;
+        let start = std::time::Instant::now();
+        for _ in 0..reps {
+            state.reset();
+            forward_mamba_backbone_prefill_mode(
+                &mut out,
+                &input,
+                &w,
+                &mut state,
+                &mut scratch,
+                &dims,
+                mode,
+            );
+        }
+        let ms = start.elapsed().as_secs_f64() * 1000.0 / reps as f64;
+        eprintln!("prefill {mode:?}: {ms:.1} ms/page (T={seq_len}, d384x24)");
+    }
+}

--- a/tests/prefill_m3.rs
+++ b/tests/prefill_m3.rs
@@ -1,0 +1,415 @@
+//! Full-sequence Mamba-3 CPU prefill contracts — the M3 twins of
+//! `prefill.rs`, plus the param-labeled M1-vs-M3 head-to-head latency probe.
+
+use mamba_rs::mamba_ssm::cpu::prefill::PrefillMode;
+use mamba_rs::mamba3_siso::Mamba3LayerFlat;
+use mamba_rs::mamba3_siso::config::Mamba3Config;
+use mamba_rs::mamba3_siso::cpu::dims::Mamba3Dims;
+use mamba_rs::mamba3_siso::cpu::forward::{Mamba3LayerStateMut, forward_mamba3_layer_batched};
+use mamba_rs::mamba3_siso::cpu::prefill::{
+    Mamba3PrefillScratch, forward_mamba3_backbone_prefill, forward_mamba3_backbone_prefill_mode,
+    prefill3_batch,
+};
+use mamba_rs::mamba3_siso::cpu::scratch::Mamba3Scratch;
+use mamba_rs::mamba3_siso::cpu::weights::{TrainMamba3LayerWeights, TrainMamba3Weights};
+use mamba_rs::mamba3_siso::state::Mamba3State;
+use mamba_rs::mamba3_siso::weights::Mamba3Weights;
+use mamba_rs::ops::blas::sgemm_forward;
+use mamba_rs::ops::fast_math::RMS_NORM_EPS;
+use mamba_rs::ops::norms::rms_norm_inplace;
+
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn test_cfg() -> Mamba3Config {
+    Mamba3Config {
+        d_model: 32,
+        d_state: 8,
+        expand: 2,
+        headdim: 8,
+        ngroups: 1,
+        n_layers: 2,
+        rope_fraction: 0.5,
+        a_floor: 0.0625,
+        is_outproj_norm: true,
+    }
+}
+
+fn train_weights_from(w: &Mamba3Weights) -> TrainMamba3Weights {
+    TrainMamba3Weights {
+        input_proj_w: w.input_proj_w.clone(),
+        input_proj_b: w.input_proj_b.clone(),
+        layers: w
+            .layers
+            .iter()
+            .map(|lw| TrainMamba3LayerWeights {
+                norm_weight: lw.norm_weight.clone(),
+                in_proj_w: lw.in_proj_w.clone(),
+                dt_bias: lw.dt_bias.clone(),
+                b_norm_weight: lw.b_norm_weight.clone(),
+                c_norm_weight: lw.c_norm_weight.clone(),
+                b_bias: lw.b_bias.clone(),
+                c_bias: lw.c_bias.clone(),
+                d_param: lw.d_param.clone(),
+                norm_gate_weight: lw.norm_gate_weight.clone(),
+                out_proj_w: lw.out_proj_w.clone(),
+            })
+            .collect(),
+        norm_f_weight: w.norm_f_weight.clone(),
+    }
+}
+
+fn assert_bits(label: &str, a: &[f32], b: &[f32]) {
+    assert_eq!(a.len(), b.len(), "{label}: length");
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        assert_eq!(x.to_bits(), y.to_bits(), "{label}[{i}]: {x} vs {y}");
+    }
+}
+
+/// Prefill (zero state) must reproduce the training layer forwards
+/// bit-for-bit: same input_proj GEMM, same per-layer math, same norm_f.
+#[test]
+fn m3_prefill_matches_training_layers_bitwise() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 8usize;
+    let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    let tw = train_weights_from(&w);
+    let input = det(seq_len * input_dim, 0xAA, 0.05);
+    let dims = Mamba3Dims::from_config(&cfg, seq_len);
+    let dm = cfg.d_model;
+    let (nh, hd, ds) = (cfg.nheads(), cfg.headdim, cfg.d_state);
+    let na = cfg.num_rope_angles().max(1);
+
+    // Reference: input_proj GEMM + training layer forwards + norm_f rows.
+    let mut ref_out = vec![0.0f32; seq_len * dm];
+    sgemm_forward(
+        &mut ref_out,
+        &input,
+        &w.input_proj_w,
+        Some(&w.input_proj_b),
+        seq_len,
+        input_dim,
+        dm,
+    );
+    let mut phase = Mamba3Scratch::zeros(&dims);
+    for lw in &tw.layers {
+        let mut acts = Mamba3LayerFlat::zeros(dims);
+        let mut ssm = vec![0.0f32; nh * hd * ds];
+        let mut k = vec![0.0f32; nh * ds];
+        let mut v = vec![0.0f32; nh * hd];
+        let mut angle = vec![0.0f32; nh * na];
+        forward_mamba3_layer_batched(
+            &mut ref_out,
+            &mut acts,
+            lw,
+            Mamba3LayerStateMut {
+                ssm: &mut ssm,
+                k: &mut k,
+                v: &mut v,
+                angle: &mut angle,
+            },
+            &mut phase,
+            &dims,
+        );
+    }
+    for row in ref_out.chunks_mut(dm) {
+        rms_norm_inplace(row, &w.norm_f_weight, RMS_NORM_EPS);
+    }
+
+    // Prefill.
+    let mut state = Mamba3State::zeros(&cfg);
+    let mut scratch = Mamba3PrefillScratch::new(&dims, input_dim);
+    let mut out = vec![0.0f32; seq_len * dm];
+    forward_mamba3_backbone_prefill(&mut out, &input, &w, &mut state.layers, &mut scratch, &dims);
+
+    assert_bits("m3 prefill vs training layers", &out, &ref_out);
+}
+
+/// Parallel mode must be bit-equal to Single — outputs AND carried states.
+#[test]
+fn m3_prefill_parallel_bit_equals_single() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 16usize;
+    let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(seq_len * input_dim, 0xAB, 0.05);
+    let dims = Mamba3Dims::from_config(&cfg, seq_len);
+
+    let run = |mode: PrefillMode| -> (Vec<f32>, Mamba3State) {
+        let mut state = Mamba3State::zeros(&cfg);
+        let mut scratch = Mamba3PrefillScratch::new(&dims, input_dim);
+        let mut out = vec![0.0f32; seq_len * cfg.d_model];
+        forward_mamba3_backbone_prefill_mode(
+            &mut out,
+            &input,
+            &w,
+            &mut state.layers,
+            &mut scratch,
+            &dims,
+            mode,
+        );
+        (out, state)
+    };
+    let (out_s, st_s) = run(PrefillMode::Single);
+    let (out_p, st_p) = run(PrefillMode::Parallel);
+    assert_bits("m3 parallel vs single output", &out_p, &out_s);
+    for (l, (a, b)) in st_s.layers.iter().zip(st_p.layers.iter()).enumerate() {
+        assert_bits(&format!("L{l} ssm_state"), &b.ssm_state, &a.ssm_state);
+        assert_bits(&format!("L{l} k_state"), &b.k_state, &a.k_state);
+        assert_bits(&format!("L{l} v_state"), &b.v_state, &a.v_state);
+        assert_bits(&format!("L{l} angle_state"), &b.angle_state, &a.angle_state);
+    }
+}
+
+/// After prefilling T tokens, the per-step decode path must continue as if
+/// all T+1 tokens had gone through the step loop (tolerance: the step path
+/// uses matvec accumulation orders, prefill uses SGEMM).
+#[test]
+fn m3_prefill_then_decode_handoff() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let seq_len = 8usize;
+    let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    let dims = Mamba3Dims::from_config(&cfg, seq_len);
+    let inputs = det((seq_len + 1) * input_dim, 0xAC, 0.05);
+    let dm = cfg.d_model;
+
+    // Reference: the pure step loop over T+1 tokens.
+    let mut ref_state = Mamba3State::zeros(&cfg);
+    let mut ref_scratch = mamba_rs::mamba3_siso::Mamba3StepScratch::new(&cfg);
+    let mut ref_last = vec![0.0f32; dm];
+    for t in 0..=seq_len {
+        mamba_rs::mamba3_siso::mamba3_step(
+            &mut ref_last,
+            &inputs[t * input_dim..(t + 1) * input_dim],
+            &mut ref_scratch,
+            &w,
+            &mut ref_state.layers,
+            &cfg,
+        );
+    }
+
+    // Prefill T, then decode token T via the step path.
+    let mut state = Mamba3State::zeros(&cfg);
+    let mut prefill_scratch = Mamba3PrefillScratch::new(&dims, input_dim);
+    let mut prefill_out = vec![0.0f32; seq_len * dm];
+    forward_mamba3_backbone_prefill(
+        &mut prefill_out,
+        &inputs[..seq_len * input_dim],
+        &w,
+        &mut state.layers,
+        &mut prefill_scratch,
+        &dims,
+    );
+    let mut step_scratch = mamba_rs::mamba3_siso::Mamba3StepScratch::new(&cfg);
+    let mut step_out = vec![0.0f32; dm];
+    mamba_rs::mamba3_siso::mamba3_step(
+        &mut step_out,
+        &inputs[seq_len * input_dim..],
+        &mut step_scratch,
+        &w,
+        &mut state.layers,
+        &cfg,
+    );
+
+    let mut dot = 0.0f64;
+    let mut na_ = 0.0f64;
+    let mut nb = 0.0f64;
+    let mut worst = 0.0f32;
+    for (&a, &b) in step_out.iter().zip(ref_last.iter()) {
+        dot += a as f64 * b as f64;
+        na_ += (a as f64).powi(2);
+        nb += (b as f64).powi(2);
+        let d = (a - b).abs();
+        worst = worst.max(d / a.abs().max(b.abs()).max(1e-3));
+    }
+    let cos = dot / (na_.sqrt() * nb.sqrt());
+    assert!(
+        cos > 0.9999 && worst < 1e-2,
+        "m3 handoff decode diverges from the step loop: cos={cos} max_rel={worst}"
+    );
+}
+
+/// The batch helper must equal per-sample sequential prefills bit-for-bit.
+#[test]
+fn m3_prefill_batch_matches_sequential() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let seq_len = 8usize;
+    let b = 3usize;
+    let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    let dims = Mamba3Dims::from_config(&cfg, seq_len);
+    let dm = cfg.d_model;
+    let inputs = det(b * seq_len * input_dim, 0xAE, 0.05);
+
+    let mut seq_out = vec![0.0f32; b * seq_len * dm];
+    for i in 0..b {
+        let mut state = Mamba3State::zeros(&cfg);
+        let mut scratch = Mamba3PrefillScratch::new(&dims, input_dim);
+        forward_mamba3_backbone_prefill(
+            &mut seq_out[i * seq_len * dm..(i + 1) * seq_len * dm],
+            &inputs[i * seq_len * input_dim..(i + 1) * seq_len * input_dim],
+            &w,
+            &mut state.layers,
+            &mut scratch,
+            &dims,
+        );
+    }
+
+    let mut states: Vec<Mamba3State> = (0..b).map(|_| Mamba3State::zeros(&cfg)).collect();
+    let mut scratches: Vec<Mamba3PrefillScratch> = (0..b)
+        .map(|_| Mamba3PrefillScratch::new(&dims, input_dim))
+        .collect();
+    let mut batch_out = vec![0.0f32; b * seq_len * dm];
+    prefill3_batch(
+        &mut batch_out,
+        &inputs,
+        &w,
+        &mut states,
+        &mut scratches,
+        &dims,
+    );
+
+    assert_bits("m3 batch vs sequential", &batch_out, &seq_out);
+}
+
+/// M1-vs-M3 prefill head-to-head at the classifier center shape (manual:
+/// --ignored). Same d_model / n_layers / input_dim / T; parameter counts are
+/// printed alongside the times so the comparison is param-labeled, not
+/// param-blind (M3 layers carry a different budget than M1 layers).
+#[test]
+#[ignore]
+fn m1_vs_m3_prefill_head_to_head() {
+    let seq_len = 4617usize;
+    let input_dim = 1024usize;
+    let reps = 3;
+
+    // M1 at the classify center shape.
+    {
+        use mamba_rs::config::MambaConfig;
+        use mamba_rs::inference::{PrefillScratch, forward_mamba_backbone_prefill_mode};
+        use mamba_rs::ops::dims::MambaDims;
+        use mamba_rs::state::MambaState;
+        use mamba_rs::weights::MambaWeights;
+        let cfg = MambaConfig {
+            d_model: 384,
+            n_layers: 24,
+            d_state: 16,
+            d_conv: 4,
+            expand: 2,
+            scan_mode: mamba_rs::config::ScanMode::Sequential,
+            rms_norm_eps: 1e-5,
+        };
+        let mut w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+        for lw in w.layers.iter_mut() {
+            lw.a_neg = lw.a_log.iter().map(|&v| -v.exp()).collect();
+        }
+        let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+        let input = det(seq_len * input_dim, 0xAF, 0.05);
+        let mut out = vec![0.0f32; seq_len * cfg.d_model];
+        let n_params = w.param_count(input_dim, &cfg);
+        for mode in [PrefillMode::Single, PrefillMode::Parallel] {
+            let mut state = MambaState::zeros(cfg.n_layers, cfg.d_inner(), cfg.d_state, cfg.d_conv);
+            let mut scratch = PrefillScratch::new(&dims);
+            forward_mamba_backbone_prefill_mode(
+                &mut out,
+                &input,
+                &w,
+                &mut state,
+                &mut scratch,
+                &dims,
+                mode,
+            );
+            let start = std::time::Instant::now();
+            for _ in 0..reps {
+                state.reset();
+                forward_mamba_backbone_prefill_mode(
+                    &mut out,
+                    &input,
+                    &w,
+                    &mut state,
+                    &mut scratch,
+                    &dims,
+                    mode,
+                );
+            }
+            let ms = start.elapsed().as_secs_f64() * 1000.0 / reps as f64;
+            eprintln!("M1 d384x24 ({n_params} params) prefill {mode:?}: {ms:.1} ms/page");
+        }
+    }
+
+    // M3 at the matched outer shape (d384 x 24 layers).
+    {
+        let cfg = Mamba3Config {
+            d_model: 384,
+            d_state: 32,
+            expand: 2,
+            headdim: 32,
+            ngroups: 1,
+            n_layers: 24,
+            rope_fraction: 0.5,
+            a_floor: 0.0625,
+            is_outproj_norm: true,
+        };
+        let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+        let dims = Mamba3Dims::from_config(&cfg, seq_len);
+        let input = det(seq_len * input_dim, 0xAF, 0.05);
+        let mut out = vec![0.0f32; seq_len * cfg.d_model];
+        let n_params: usize = w.input_proj_w.len()
+            + w.input_proj_b.len()
+            + w.norm_f_weight.len()
+            + w.layers
+                .iter()
+                .map(|l| {
+                    l.norm_weight.len()
+                        + l.in_proj_w.len()
+                        + l.dt_bias.len()
+                        + l.b_norm_weight.len()
+                        + l.c_norm_weight.len()
+                        + l.b_bias.len()
+                        + l.c_bias.len()
+                        + l.d_param.len()
+                        + l.norm_gate_weight.len()
+                        + l.out_proj_w.len()
+                })
+                .sum::<usize>();
+        for mode in [PrefillMode::Single, PrefillMode::Parallel] {
+            let mut state = Mamba3State::zeros(&cfg);
+            let mut scratch = Mamba3PrefillScratch::new(&dims, input_dim);
+            forward_mamba3_backbone_prefill_mode(
+                &mut out,
+                &input,
+                &w,
+                &mut state.layers,
+                &mut scratch,
+                &dims,
+                mode,
+            );
+            let start = std::time::Instant::now();
+            for _ in 0..reps {
+                state.reset();
+                forward_mamba3_backbone_prefill_mode(
+                    &mut out,
+                    &input,
+                    &w,
+                    &mut state.layers,
+                    &mut scratch,
+                    &dims,
+                    mode,
+                );
+            }
+            let ms = start.elapsed().as_secs_f64() * 1000.0 / reps as f64;
+            eprintln!("M3 d384x24 ({n_params} params) prefill {mode:?}: {ms:.1} ms/page");
+        }
+    }
+}

--- a/tests/sgemm_bi_typed_parity.rs
+++ b/tests/sgemm_bi_typed_parity.rs
@@ -531,3 +531,20 @@ fn typed_forward_is_batch_invariant_within_bucket() {
         }
     }
 }
+
+/// Classifier patch-embed (input_proj) GEMM shapes: fwd NN
+/// [B*T=18468, P^2=1024, d_model=384] and its dW TN twin, through the
+/// full-coverage entries the production path uses. Proves bucket/fallback
+/// coverage under the bit contract for the vision-training GEMMs.
+#[test]
+fn typed_classifier_input_proj_shapes_bit_match() {
+    let t = Ctx::new();
+    for dt in [WeightDtype::Bf16, WeightDtype::F16] {
+        check_forward(&t, dt, (18468, 1024, 384), true, true);
+        check_dw(&t, dt, (18468, 1024, 384), true);
+        // Tiny-M + K-tail combo (the capture-regression trainer shape):
+        // bt=4, input_dim=200, d_model=32.
+        check_forward(&t, dt, (4, 200, 32), true, true);
+        check_dw(&t, dt, (4, 200, 32), true);
+    }
+}

--- a/tests/trainer_split.rs
+++ b/tests/trainer_split.rs
@@ -472,3 +472,121 @@ fn f16_split_scaler_protocol() {
     assert_eq!(m.overflow_skipped, Some(false));
     assert!(m.optimizer_stepped);
 }
+
+fn flat_weights(s: &MambaWeights) -> Vec<f32> {
+    let mut v = Vec::new();
+    v.extend_from_slice(&s.input_proj_w);
+    v.extend_from_slice(&s.input_proj_b);
+    for l in &s.layers {
+        v.extend_from_slice(&l.norm_weight);
+        v.extend_from_slice(&l.in_proj_w);
+        v.extend_from_slice(&l.conv1d_weight);
+        v.extend_from_slice(&l.conv1d_bias);
+        v.extend_from_slice(&l.x_proj_w);
+        v.extend_from_slice(&l.dt_proj_w);
+        v.extend_from_slice(&l.dt_proj_b);
+        v.extend_from_slice(&l.a_log);
+        v.extend_from_slice(&l.d_param);
+        v.extend_from_slice(&l.out_proj_w);
+    }
+    v.extend_from_slice(&s.norm_f_weight);
+    v
+}
+
+/// The first AdamW update is exactly proportional to lr — the
+/// `m_hat/(sqrt(v_hat)+eps)` term is lr-independent and the decoupled decay
+/// term carries lr too — so set_lr(10x) must scale the first-step weight
+/// delta ~10x.
+#[test]
+fn set_lr_scales_first_step_delta() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let w0 = flat_weights(&w);
+
+    let max_delta = |snapshot: &MambaWeights| -> f64 {
+        flat_weights(snapshot)
+            .iter()
+            .zip(w0.iter())
+            .map(|(a, b)| (a - b).abs() as f64)
+            .fold(0.0, f64::max)
+    };
+
+    let mut a = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer a");
+    assert!((a.lr() - 1e-3).abs() < 1e-9);
+    a.step(&input, &d_temporal).expect("step a");
+    let da = max_delta(&a.snapshot_master().expect("a"));
+
+    let mut b = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer b");
+    b.set_lr(1e-2).expect("set_lr");
+    assert!((b.lr() - 1e-2).abs() < 1e-9);
+    b.step(&input, &d_temporal).expect("step b");
+    let db = max_delta(&b.snapshot_master().expect("b"));
+
+    let ratio = db / da;
+    assert!(
+        (9.5..10.5).contains(&ratio),
+        "set_lr(10x) must scale the first-step delta ~10x: got {ratio} ({da} -> {db})"
+    );
+
+    assert!(b.set_lr(0.0).is_err(), "lr=0 must be rejected");
+    assert!(b.set_lr(f32::NAN).is_err(), "NaN lr must be rejected");
+}
+
+/// set_lr under a captured graph errs (the lr is baked into the captured
+/// AdamW kernel); drop_graph unblocks it and steps fall back to eager.
+#[test]
+fn set_lr_under_graph_errs_and_drop_graph_unblocks() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+    t.step(&input, &d_temporal).expect("warmup");
+    t.capture_graph().expect("capture");
+    assert!(t.has_graph());
+    let m = t.step(&input, &d_temporal).expect("graph step");
+    assert!(m.graph_replayed);
+
+    assert!(
+        t.set_lr(5e-4).is_err(),
+        "set_lr under a captured graph must err"
+    );
+
+    t.drop_graph();
+    assert!(!t.has_graph());
+    t.set_lr(5e-4).expect("set_lr after drop_graph");
+    assert!((t.lr() - 5e-4).abs() < 1e-9);
+    let m2 = t.step(&input, &d_temporal).expect("eager step");
+    assert!(
+        !m2.graph_replayed,
+        "after drop_graph steps must run eagerly"
+    );
+}

--- a/tests/trainer_split.rs
+++ b/tests/trainer_split.rs
@@ -130,7 +130,9 @@ fn run_split_vs_fused(dtype: WeightDtype) {
 
     let mut w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
     if !matches!(dtype, WeightDtype::F32) {
-        // Mixed trainers support only the identity input_proj branch today.
+        // Keep the Mixed variant on the identity D2D branch — this test IS
+        // the identity-path regression; the trainable input_proj has its
+        // own split-vs-fused test below.
         w.input_proj_w.clear();
         w.input_proj_b.clear();
     }
@@ -716,4 +718,146 @@ fn reference_no_decay_masks_exactly_the_named_tensors() {
     g.step(&input, &d_temporal).expect("warmup");
     g.capture_graph().expect("capture");
     assert!(g.set_reference_no_decay(true).is_err());
+}
+
+/// bf16 with a REAL rectangular input_proj (the vision patch-embed shape):
+/// constructs (the guard is gone), trains it (input_proj_w/b move), and the
+/// split==fused bit-identity holds through the new branch.
+#[test]
+fn bf16_trainable_input_proj_split_matches_fused() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    let (batch, seq_len) = (2usize, 8usize);
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+
+    let mut fused = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("fused trainer");
+    let mut split = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("split trainer");
+    let mut out = vec![0.0f32; n_out];
+    for step in 0..3u32 {
+        let input = det(n_in, 0xA0 + step, 0.05);
+        let d_temporal = det(n_out, 0xB0 + step, 0.01);
+        fused.step(&input, &d_temporal).expect("fused step");
+        split.forward(&input, &mut out).expect("split fwd");
+        split
+            .backward_step(&d_temporal, BackwardOpts::default())
+            .expect("split bwd");
+    }
+    let sa = fused.snapshot_master().expect("fused snapshot");
+    let sb = split.snapshot_master().expect("split snapshot");
+    assert_snapshots_bit_eq(&sa, &sb, "bf16 rect input_proj split-vs-fused");
+
+    // The patch embed actually trained.
+    assert!(
+        sa.input_proj_w
+            .iter()
+            .zip(w.input_proj_w.iter())
+            .any(|(a, b)| a != b),
+        "input_proj_w never moved over 3 steps"
+    );
+    assert!(
+        sa.input_proj_b
+            .iter()
+            .zip(w.input_proj_b.iter())
+            .any(|(a, b)| a != b),
+        "input_proj_b never moved over 3 steps"
+    );
+}
+
+/// Presize-twin regression (bug #1): a patch dim exceeding every backbone
+/// dim under batch-invariant graph capture. Without the input_dim-aware
+/// presize, the upcast scratch grows INSIDE capture (illegal alloc) or
+/// after it (freed-pointer replay).
+#[test]
+fn bf16_input_proj_graph_capture_with_large_patch_dim() {
+    let cfg = test_cfg(); // d_model=32, d_inner=64 -> 2*d_inner = 128
+    let input_dim = 200usize; // exceeds max(d_model, 2*d_inner, xdbl_dim)
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("trainer");
+    t.ctx().set_batch_invariant(true);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    t.step(&input, &d_temporal).expect("warmup");
+    t.capture_graph().expect("capture");
+    let m = t.step(&input, &d_temporal).expect("replay 1");
+    assert!(m.graph_replayed);
+    t.step(&input, &d_temporal).expect("replay 2");
+}
+
+/// Bisection probe: batch-invariant mode + trainable input_proj, EAGER only.
+#[test]
+fn bf16_input_proj_eager_under_batch_invariant() {
+    let cfg = test_cfg();
+    let input_dim = 20usize;
+    eager_bi_probe(cfg, input_dim);
+}
+
+/// Same probe at the large patch dim.
+#[test]
+fn bf16_input_proj_eager_under_batch_invariant_large() {
+    let cfg = test_cfg();
+    let input_dim = 200usize;
+    eager_bi_probe(cfg, input_dim);
+}
+
+/// Forward-only variant of the probe (the split API syncs internally).
+#[test]
+fn bf16_input_proj_eager_bi_large_forward_only() {
+    let cfg = test_cfg();
+    let input_dim = 200usize;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("trainer");
+    t.ctx().set_batch_invariant(true);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+    t.forward(&input, &mut out).expect("BI forward only");
+}
+
+fn eager_bi_probe(cfg: MambaConfig, input_dim: usize) {
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::Bf16,
+    )
+    .expect("trainer");
+    t.ctx().set_batch_invariant(true);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    t.step(&input, &d_temporal).expect("eager BI step");
+    t.step(&input, &d_temporal).expect("eager BI step 2");
 }

--- a/tests/trainer_split.rs
+++ b/tests/trainer_split.rs
@@ -590,3 +590,130 @@ fn set_lr_under_graph_errs_and_drop_graph_unblocks() {
         "after drop_graph steps must run eagerly"
     );
 }
+
+/// Reference no-decay groups: with the mask ON, masked tensors (a_log,
+/// d_param, dt_proj_b, norm scales) skip the decoupled decay term exactly
+/// (w_on - w_off == lr*wd*w0 elementwise), while unmasked tensors stay
+/// bit-identical to the mask-OFF run. Default OFF must be the historical
+/// behavior.
+#[test]
+fn reference_no_decay_masks_exactly_the_named_tensors() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let d_temporal = det(batch * seq_len * cfg.d_model, 0xBB, 0.01);
+    let (lr, wd) = (1e-3f64, 1e-2f64);
+
+    let mut off = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("off trainer");
+    off.step(&input, &d_temporal).expect("off step");
+    let s_off = off.snapshot_master().expect("off snapshot");
+
+    let mut on = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("on trainer");
+    on.set_reference_no_decay(true).expect("enable mask");
+    on.step(&input, &d_temporal).expect("on step");
+    let s_on = on.snapshot_master().expect("on snapshot");
+
+    // Unmasked tensors: bit-identical between the two runs.
+    let unmasked = |s: &MambaWeights| -> Vec<f32> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&s.input_proj_w);
+        v.extend_from_slice(&s.input_proj_b);
+        for l in &s.layers {
+            v.extend_from_slice(&l.in_proj_w);
+            v.extend_from_slice(&l.conv1d_weight);
+            v.extend_from_slice(&l.conv1d_bias);
+            v.extend_from_slice(&l.x_proj_w);
+            v.extend_from_slice(&l.dt_proj_w);
+            v.extend_from_slice(&l.out_proj_w);
+        }
+        v
+    };
+    for (i, (a, b)) in unmasked(&s_off)
+        .iter()
+        .zip(unmasked(&s_on).iter())
+        .enumerate()
+    {
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "unmasked tensor element [{i}] changed under the mask: {a} vs {b}"
+        );
+    }
+
+    // Masked tensors: w_on - w_off == lr*wd*w0 (the decay term), elementwise.
+    let masked_with_origin = |s: &MambaWeights, w0: &MambaWeights| -> Vec<(f32, f32)> {
+        let mut v: Vec<(f32, f32)> = Vec::new();
+        for (l, l0) in s.layers.iter().zip(w0.layers.iter()) {
+            v.extend(
+                l.norm_weight
+                    .iter()
+                    .copied()
+                    .zip(l0.norm_weight.iter().copied()),
+            );
+            v.extend(
+                l.dt_proj_b
+                    .iter()
+                    .copied()
+                    .zip(l0.dt_proj_b.iter().copied()),
+            );
+            v.extend(l.a_log.iter().copied().zip(l0.a_log.iter().copied()));
+            v.extend(l.d_param.iter().copied().zip(l0.d_param.iter().copied()));
+        }
+        v.extend(
+            s.norm_f_weight
+                .iter()
+                .copied()
+                .zip(w0.norm_f_weight.iter().copied()),
+        );
+        v
+    };
+    let off_m = masked_with_origin(&s_off, &w);
+    let on_m = masked_with_origin(&s_on, &w);
+    let mut any_moved = false;
+    for (i, ((a, w0), (b, _))) in off_m.iter().zip(on_m.iter()).enumerate() {
+        let expected_gap = lr * wd * (*w0 as f64);
+        let gap = (*b as f64) - (*a as f64);
+        // Tolerance: the OFF run computes w0*(1 - lr*wd) in f32, whose
+        // rounding is ~ulp(w0) = |w0| * 2^-23 — the dominant error term,
+        // proportional to |w0| (not to the tiny decay gap itself).
+        let tol = 1e-7 + (*w0 as f64).abs() * 5e-7;
+        assert!(
+            (gap - expected_gap).abs() < tol,
+            "masked element [{i}]: gap {gap:e} vs expected decay term {expected_gap:e} \
+             (tol {tol:e})"
+        );
+        if gap.abs() > 0.0 {
+            any_moved = true;
+        }
+    }
+    assert!(any_moved, "the mask never changed a single masked element");
+
+    // Toggle under a captured graph must err.
+    let mut g = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("graph trainer");
+    g.step(&input, &d_temporal).expect("warmup");
+    g.capture_graph().expect("capture");
+    assert!(g.set_reference_no_decay(true).is_err());
+}

--- a/tests/trainer_split.rs
+++ b/tests/trainer_split.rs
@@ -1,0 +1,474 @@
+//! Split-step API contracts: `MambaTrainer::forward` / `backward_step`
+//! against the fused `step()`.
+//!
+//! The split is specified as an EAGER re-composition of the exact eager
+//! phase bodies the fused step runs, so:
+//!   - split == fused must be bit-identical on the master weights (F32 and
+//!     bf16) — same kernels, same order, only host-side orchestration moves;
+//!   - forward() alone must leave the optimizer and weights untouched;
+//!   - the accumulate_only window must be exact ("don't zero, don't run the
+//!     tail") and the fused step() must refuse to run while it is open
+//!     (its captured/eager body zeroes the arena — the zero-state bug class);
+//!   - f16 rides the GradScaler protocol and rejects accumulate_only.
+
+#![cfg(feature = "cuda")]
+
+use mamba_rs::config::MambaConfig;
+use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+use mamba_rs::mamba_ssm::gpu::trainer::{BackwardOpts, MambaTrainer, TrainSessionCfg};
+use mamba_rs::ops::dims::{MambaDims, MambaRecurrentState};
+use mamba_rs::train::flat::MambaBackboneFlat;
+use mamba_rs::train::forward::forward_mamba_backbone_batched;
+use mamba_rs::train::scratch::PhaseScratch;
+use mamba_rs::train::weights::{TrainMambaLayerWeights, TrainMambaWeights};
+use mamba_rs::weights::MambaWeights;
+
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn test_cfg() -> MambaConfig {
+    MambaConfig {
+        d_model: 32,
+        n_layers: 2,
+        d_state: 8,
+        d_conv: 4,
+        expand: 2,
+        scan_mode: mamba_rs::config::ScanMode::Sequential,
+        rms_norm_eps: 1e-5,
+    }
+}
+
+fn session(batch: usize, seq_len: usize, input_dim: usize) -> TrainSessionCfg {
+    TrainSessionCfg {
+        input_dim,
+        batch,
+        seq_len,
+        lr: 1e-3,
+        weight_decay: 1e-2,
+    }
+}
+
+/// Bit-exact comparison of two weight snapshots, tensor by tensor.
+fn assert_snapshots_bit_eq(a: &MambaWeights, b: &MambaWeights, ctx_msg: &str) {
+    let pairs: Vec<(&str, &[f32], &[f32])> = {
+        let mut v: Vec<(&str, &[f32], &[f32])> = vec![
+            ("input_proj_w", &a.input_proj_w, &b.input_proj_w),
+            ("input_proj_b", &a.input_proj_b, &b.input_proj_b),
+            ("norm_f_weight", &a.norm_f_weight, &b.norm_f_weight),
+        ];
+        for (la, lb) in a.layers.iter().zip(b.layers.iter()) {
+            v.extend([
+                (
+                    "norm_weight",
+                    la.norm_weight.as_slice(),
+                    lb.norm_weight.as_slice(),
+                ),
+                (
+                    "in_proj_w",
+                    la.in_proj_w.as_slice(),
+                    lb.in_proj_w.as_slice(),
+                ),
+                (
+                    "conv1d_weight",
+                    la.conv1d_weight.as_slice(),
+                    lb.conv1d_weight.as_slice(),
+                ),
+                (
+                    "conv1d_bias",
+                    la.conv1d_bias.as_slice(),
+                    lb.conv1d_bias.as_slice(),
+                ),
+                ("x_proj_w", la.x_proj_w.as_slice(), lb.x_proj_w.as_slice()),
+                (
+                    "dt_proj_w",
+                    la.dt_proj_w.as_slice(),
+                    lb.dt_proj_w.as_slice(),
+                ),
+                (
+                    "dt_proj_b",
+                    la.dt_proj_b.as_slice(),
+                    lb.dt_proj_b.as_slice(),
+                ),
+                ("a_log", la.a_log.as_slice(), lb.a_log.as_slice()),
+                ("d_param", la.d_param.as_slice(), lb.d_param.as_slice()),
+                (
+                    "out_proj_w",
+                    la.out_proj_w.as_slice(),
+                    lb.out_proj_w.as_slice(),
+                ),
+            ]);
+        }
+        v
+    };
+    for (name, xa, xb) in pairs {
+        assert_eq!(xa.len(), xb.len(), "{ctx_msg}: {name} length mismatch");
+        for (i, (va, vb)) in xa.iter().zip(xb.iter()).enumerate() {
+            assert_eq!(
+                va.to_bits(),
+                vb.to_bits(),
+                "{ctx_msg}: {name}[{i}] differs: {va} vs {vb}"
+            );
+        }
+    }
+}
+
+fn run_split_vs_fused(dtype: WeightDtype) {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (2usize, 8usize);
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+
+    let mut w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    if !matches!(dtype, WeightDtype::F32) {
+        // Mixed trainers support only the identity input_proj branch today.
+        w.input_proj_w.clear();
+        w.input_proj_b.clear();
+    }
+
+    let mut fused = MambaTrainer::new_full(0, &w, cfg, session(batch, seq_len, input_dim), dtype)
+        .expect("fused trainer");
+    let mut split = MambaTrainer::new_full(0, &w, cfg, session(batch, seq_len, input_dim), dtype)
+        .expect("split trainer");
+
+    let mut temporal_out = vec![0.0f32; n_out];
+    for step in 0..3u32 {
+        let input = det(n_in, 0xA0 + step, 0.05);
+        let d_temporal = det(n_out, 0xB0 + step, 0.01);
+
+        let fm = fused.step(&input, &d_temporal).expect("fused step");
+        assert!(!fm.graph_replayed);
+
+        split
+            .forward(&input, &mut temporal_out)
+            .expect("split forward");
+        let bm = split
+            .backward_step(&d_temporal, BackwardOpts::default())
+            .expect("split backward");
+        assert!(bm.optimizer_stepped);
+        assert_eq!(bm.step, fm.step, "adam step counters diverged");
+    }
+
+    let sa = fused.snapshot_master().expect("fused snapshot");
+    let sb = split.snapshot_master().expect("split snapshot");
+    assert_snapshots_bit_eq(&sa, &sb, &format!("split-vs-fused {dtype:?}"));
+}
+
+#[test]
+fn split_matches_fused_bit_identical_f32() {
+    run_split_vs_fused(WeightDtype::F32);
+}
+
+#[test]
+fn split_matches_fused_bit_identical_bf16() {
+    run_split_vs_fused(WeightDtype::Bf16);
+}
+
+/// The forward readback must be the post-norm_f training-forward output:
+/// compare against the CPU batched training forward on identical weights.
+#[test]
+fn forward_temporal_matches_cpu_training_forward() {
+    let cfg = test_cfg();
+    let input_dim = 20usize; // rectangular input_proj — the vision shape
+    let (batch, seq_len) = (1usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+
+    let mut trainer = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+    let mut gpu_out = vec![0.0f32; batch * seq_len * cfg.d_model];
+    trainer.forward(&input, &mut gpu_out).expect("forward");
+
+    // CPU reference (batch=1: single flat sequence).
+    let tw = TrainMambaWeights {
+        input_proj_w: w.input_proj_w.clone(),
+        input_proj_b: w.input_proj_b.clone(),
+        layers: w
+            .layers
+            .iter()
+            .map(|lw| TrainMambaLayerWeights {
+                norm_weight: lw.norm_weight.clone(),
+                in_proj_w: lw.in_proj_w.clone(),
+                conv1d_weight: lw.conv1d_weight.clone(),
+                conv1d_bias: lw.conv1d_bias.clone(),
+                x_proj_w: lw.x_proj_w.clone(),
+                dt_proj_w: lw.dt_proj_w.clone(),
+                dt_proj_b: lw.dt_proj_b.clone(),
+                a_log: lw.a_log.clone(),
+                d_param: lw.d_param.clone(),
+                out_proj_w: lw.out_proj_w.clone(),
+            })
+            .collect(),
+        norm_f_weight: w.norm_f_weight.clone(),
+    };
+    let dims = MambaDims::from_config(&cfg, seq_len, input_dim);
+    let di = cfg.d_inner();
+    let (ds, dc, nl) = (cfg.d_state, cfg.d_conv, cfg.n_layers);
+    let mut a_neg = vec![0.0f32; nl * di * ds];
+    for (l, lw) in w.layers.iter().enumerate() {
+        for i in 0..di * ds {
+            a_neg[l * di * ds + i] = -lw.a_log[i].exp();
+        }
+    }
+    let mut acts = MambaBackboneFlat::zeros(dims);
+    let mut scratch = PhaseScratch::zeros(&dims);
+    let mut conv = vec![0.0f32; nl * di * dc];
+    let mut ssm = vec![0.0f32; nl * di * ds];
+    let mut state = MambaRecurrentState {
+        conv: &mut conv,
+        ssm: &mut ssm,
+        a_neg: &a_neg,
+    };
+    let mut cpu_out = vec![0.0f32; seq_len * cfg.d_model];
+    forward_mamba_backbone_batched(
+        &mut cpu_out,
+        &mut acts,
+        &tw,
+        &input,
+        &mut state,
+        &mut scratch,
+        &dims,
+    );
+
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (&a, &b) in gpu_out.iter().zip(cpu_out.iter()) {
+        dot += a as f64 * b as f64;
+        na += (a as f64).powi(2);
+        nb += (b as f64).powi(2);
+    }
+    let cos = dot / (na.sqrt() * nb.sqrt());
+    assert!(
+        cos > 0.9999,
+        "GPU forward() vs CPU training forward: cos={cos} (expected > 0.9999)"
+    );
+}
+
+/// forward() alone must not touch the optimizer or any weight.
+#[test]
+fn forward_alone_leaves_optimizer_untouched() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (2usize, 8usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut trainer = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+
+    let before = trainer.snapshot_master().expect("before");
+    let input = det(batch * seq_len * input_dim, 0xAA, 0.05);
+    let mut out = vec![0.0f32; batch * seq_len * cfg.d_model];
+    trainer.forward(&input, &mut out).expect("forward 1");
+    trainer.forward(&input, &mut out).expect("forward 2");
+    let after = trainer.snapshot_master().expect("after");
+    assert_snapshots_bit_eq(&before, &after, "forward-only");
+}
+
+/// Interlock: backward without forward errs; the fused step() refuses to run
+/// while an accumulate window is open; closing the window restores it.
+#[test]
+fn split_interlock_and_accumulate_window() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+    let input = det(n_in, 0xAA, 0.05);
+    let d_temporal = det(n_out, 0xBB, 0.01);
+    let mut out = vec![0.0f32; n_out];
+
+    // Backward with no pending forward → Err.
+    assert!(
+        t.backward_step(&d_temporal, BackwardOpts::default())
+            .is_err()
+    );
+
+    // Open an accumulation window.
+    t.forward(&input, &mut out).expect("forward");
+    let m = t
+        .backward_step(
+            &d_temporal,
+            BackwardOpts::default().with_accumulate_only(true),
+        )
+        .expect("accumulate backward");
+    assert!(!m.optimizer_stepped);
+    assert_eq!(m.step, 0, "accumulate-only must not advance adam");
+
+    // Fused step must refuse while the window is open.
+    assert!(t.step(&input, &d_temporal).is_err());
+
+    // A second backward needs its own forward.
+    assert!(
+        t.backward_step(&d_temporal, BackwardOpts::default())
+            .is_err()
+    );
+
+    // Close the window; the fused step works again.
+    t.forward(&input, &mut out).expect("forward 2");
+    let m2 = t
+        .backward_step(&d_temporal, BackwardOpts::default())
+        .expect("closing backward");
+    assert!(m2.optimizer_stepped);
+    assert_eq!(m2.step, 1);
+    t.step(&input, &d_temporal).expect("fused step after close");
+}
+
+/// Two accumulated micro-batches (batch=1, state reset between) vs one
+/// big batch (batch=2) of the same samples: gradients sum either way, so
+/// the resulting weights must agree. Exact bitness across DIFFERENT GEMM
+/// batch shapes is reported but asserted only at tight tolerance — the
+/// batch-invariant contract is per-bucket row-0 identity, not cross-shape
+/// reduction-order identity.
+#[test]
+fn accumulation_two_micro_equals_one_big_batch() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let seq_len = 8usize;
+    let w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+
+    let n_in1 = seq_len * input_dim;
+    let n_out1 = seq_len * cfg.d_model;
+    let s1_in = det(n_in1, 0xA1, 0.05);
+    let s2_in = det(n_in1, 0xA2, 0.05);
+    let s1_dt = det(n_out1, 0xB1, 0.01);
+    let s2_dt = det(n_out1, 0xB2, 0.01);
+
+    // Big batch: both samples in one call.
+    let mut big =
+        MambaTrainer::new_full(0, &w, cfg, session(2, seq_len, input_dim), WeightDtype::F32)
+            .expect("big trainer");
+    big.ctx().set_batch_invariant(true);
+    let big_in: Vec<f32> = s1_in.iter().chain(s2_in.iter()).copied().collect();
+    let big_dt: Vec<f32> = s1_dt.iter().chain(s2_dt.iter()).copied().collect();
+    let mut big_out = vec![0.0f32; 2 * n_out1];
+    big.forward(&big_in, &mut big_out).expect("big forward");
+    big.backward_step(&big_dt, BackwardOpts::default())
+        .expect("big backward");
+    let sa = big.snapshot_master().expect("big snapshot");
+
+    // Micro: accumulate sample 1, reset state, apply on sample 2.
+    let mut micro =
+        MambaTrainer::new_full(0, &w, cfg, session(1, seq_len, input_dim), WeightDtype::F32)
+            .expect("micro trainer");
+    micro.ctx().set_batch_invariant(true);
+    let mut out = vec![0.0f32; n_out1];
+    micro.forward(&s1_in, &mut out).expect("micro fwd 1");
+    micro
+        .backward_step(&s1_dt, BackwardOpts::default().with_accumulate_only(true))
+        .expect("micro bwd 1");
+    micro.reset_state().expect("reset");
+    micro.forward(&s2_in, &mut out).expect("micro fwd 2");
+    micro
+        .backward_step(&s2_dt, BackwardOpts::default())
+        .expect("micro bwd 2");
+    let sb = micro.snapshot_master().expect("micro snapshot");
+
+    // Tight-tolerance comparison + informational bit report.
+    let mut worst = 0.0f32;
+    let mut bit_equal = true;
+    let flat = |s: &MambaWeights| -> Vec<f32> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&s.input_proj_w);
+        v.extend_from_slice(&s.input_proj_b);
+        for l in &s.layers {
+            v.extend_from_slice(&l.norm_weight);
+            v.extend_from_slice(&l.in_proj_w);
+            v.extend_from_slice(&l.conv1d_weight);
+            v.extend_from_slice(&l.conv1d_bias);
+            v.extend_from_slice(&l.x_proj_w);
+            v.extend_from_slice(&l.dt_proj_w);
+            v.extend_from_slice(&l.dt_proj_b);
+            v.extend_from_slice(&l.a_log);
+            v.extend_from_slice(&l.d_param);
+            v.extend_from_slice(&l.out_proj_w);
+        }
+        v.extend_from_slice(&s.norm_f_weight);
+        v
+    };
+    for (a, b) in flat(&sa).iter().zip(flat(&sb).iter()) {
+        if a.to_bits() != b.to_bits() {
+            bit_equal = false;
+        }
+        let d = (a - b).abs();
+        let denom = a.abs().max(b.abs()).max(1e-4);
+        worst = worst.max(d / denom);
+    }
+    eprintln!("accumulation vs big-batch: bit_equal={bit_equal} max_rel={worst:e}");
+    assert!(
+        worst < 1e-5,
+        "accumulated micro-batches diverge from the big batch: max_rel={worst:e}"
+    );
+}
+
+/// f16 split: GradScaler protocol rides backward_step; accumulate_only errs.
+#[test]
+fn f16_split_scaler_protocol() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let mut w = MambaWeights::init(&cfg, input_dim, 0xC0FFEE);
+    w.input_proj_w.clear();
+    w.input_proj_b.clear();
+    let mut t = MambaTrainer::new_full(
+        0,
+        &w,
+        cfg,
+        session(batch, seq_len, input_dim),
+        WeightDtype::F16,
+    )
+    .expect("f16 trainer");
+
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+    let input = det(n_in, 0xAA, 0.05);
+    let d_temporal = det(n_out, 0xBB, 0.01);
+    let mut out = vec![0.0f32; n_out];
+
+    t.forward(&input, &mut out).expect("forward");
+    assert!(
+        t.backward_step(
+            &d_temporal,
+            BackwardOpts::default().with_accumulate_only(true)
+        )
+        .is_err(),
+        "f16 + accumulate_only must be rejected"
+    );
+    // The rejected call must not have consumed the pending forward.
+    let m = t
+        .backward_step(&d_temporal, BackwardOpts::default())
+        .expect("f16 backward");
+    assert!(m.loss_scale.is_some());
+    assert_eq!(m.overflow_skipped, Some(false));
+    assert!(m.optimizer_stepped);
+}

--- a/tests/trainer_split_m3.rs
+++ b/tests/trainer_split_m3.rs
@@ -1,0 +1,271 @@
+//! M3 split-step API contracts: `Mamba3Trainer::forward` / `backward_step`
+//! against the fused `step()` — the M3 twins of `trainer_split.rs`.
+//!
+//! Same specification: the split is an EAGER re-composition of the exact
+//! eager phase bodies the fused step runs, so split == fused must be
+//! bit-identical on the master weights; the accumulate_only window must be
+//! exact and the fused step must refuse while it is open; f16 rides the
+//! GradScaler protocol and rejects accumulate_only.
+
+#![cfg(feature = "cuda")]
+
+use mamba_rs::mamba_ssm::gpu::dtype::WeightDtype;
+use mamba_rs::mamba3_siso::config::Mamba3Config;
+use mamba_rs::mamba3_siso::gpu::trainer::{BackwardOpts, Mamba3Trainer, TrainSessionCfg};
+use mamba_rs::mamba3_siso::weights::Mamba3Weights;
+
+fn det(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            ((s & 0xFFFF) as f32 / 65536.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn test_cfg() -> Mamba3Config {
+    Mamba3Config {
+        d_model: 32,
+        d_state: 8,
+        expand: 2,
+        headdim: 8,
+        ngroups: 1,
+        n_layers: 2,
+        rope_fraction: 0.5,
+        a_floor: 0.0625,
+        is_outproj_norm: true,
+    }
+}
+
+fn session(batch: usize, seq_len: usize, input_dim: usize) -> TrainSessionCfg {
+    TrainSessionCfg {
+        input_dim,
+        batch,
+        seq_len,
+        lr: 1e-3,
+        weight_decay: 1e-2,
+    }
+}
+
+/// Bit-exact comparison of two M3 weight snapshots, tensor by tensor.
+fn assert_snapshots_bit_eq(a: &Mamba3Weights, b: &Mamba3Weights, ctx_msg: &str) {
+    let mut pairs: Vec<(&str, &[f32], &[f32])> = vec![
+        ("input_proj_w", &a.input_proj_w, &b.input_proj_w),
+        ("input_proj_b", &a.input_proj_b, &b.input_proj_b),
+        ("norm_f_weight", &a.norm_f_weight, &b.norm_f_weight),
+    ];
+    for (la, lb) in a.layers.iter().zip(b.layers.iter()) {
+        pairs.extend([
+            (
+                "norm_weight",
+                la.norm_weight.as_slice(),
+                lb.norm_weight.as_slice(),
+            ),
+            (
+                "in_proj_w",
+                la.in_proj_w.as_slice(),
+                lb.in_proj_w.as_slice(),
+            ),
+            ("dt_bias", la.dt_bias.as_slice(), lb.dt_bias.as_slice()),
+            (
+                "b_norm_weight",
+                la.b_norm_weight.as_slice(),
+                lb.b_norm_weight.as_slice(),
+            ),
+            (
+                "c_norm_weight",
+                la.c_norm_weight.as_slice(),
+                lb.c_norm_weight.as_slice(),
+            ),
+            ("b_bias", la.b_bias.as_slice(), lb.b_bias.as_slice()),
+            ("c_bias", la.c_bias.as_slice(), lb.c_bias.as_slice()),
+            ("d_param", la.d_param.as_slice(), lb.d_param.as_slice()),
+            (
+                "norm_gate_weight",
+                la.norm_gate_weight.as_slice(),
+                lb.norm_gate_weight.as_slice(),
+            ),
+            (
+                "out_proj_w",
+                la.out_proj_w.as_slice(),
+                lb.out_proj_w.as_slice(),
+            ),
+        ]);
+    }
+    for (name, xa, xb) in pairs {
+        assert_eq!(xa.len(), xb.len(), "{ctx_msg}: {name} length mismatch");
+        for (i, (va, vb)) in xa.iter().zip(xb.iter()).enumerate() {
+            assert_eq!(
+                va.to_bits(),
+                vb.to_bits(),
+                "{ctx_msg}: {name}[{i}] differs: {va} vs {vb}"
+            );
+        }
+    }
+}
+
+fn run_split_vs_fused(dtype: WeightDtype) {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (2usize, 8usize);
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+
+    let mut w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    if !matches!(dtype, WeightDtype::F32) {
+        // The M3 mixed pipeline supports the identity D2D branch only.
+        w.input_proj_w.clear();
+        w.input_proj_b.clear();
+    }
+
+    let mut fused = Mamba3Trainer::new_full(
+        0,
+        &w,
+        cfg.clone(),
+        session(batch, seq_len, input_dim),
+        dtype,
+    )
+    .expect("fused trainer");
+    let mut split = Mamba3Trainer::new_full(0, &w, cfg, session(batch, seq_len, input_dim), dtype)
+        .expect("split trainer");
+
+    let mut temporal_out = vec![0.0f32; n_out];
+    for step in 0..3u32 {
+        let input = det(n_in, 0xA0 + step, 0.05);
+        let d_temporal = det(n_out, 0xB0 + step, 0.01);
+
+        let fm = fused.step(&input, &d_temporal).expect("fused step");
+        assert!(!fm.graph_replayed);
+
+        split
+            .forward(&input, &mut temporal_out)
+            .expect("split forward");
+        let bm = split
+            .backward_step(&d_temporal, BackwardOpts::default())
+            .expect("split backward");
+        assert!(bm.optimizer_stepped);
+        assert_eq!(bm.step, fm.step, "adam step counters diverged");
+    }
+
+    let sa = fused.snapshot_master().expect("fused snapshot");
+    let sb = split.snapshot_master().expect("split snapshot");
+    assert_snapshots_bit_eq(&sa, &sb, &format!("M3 split-vs-fused {dtype:?}"));
+}
+
+#[test]
+fn m3_split_matches_fused_bit_identical_f32() {
+    run_split_vs_fused(WeightDtype::F32);
+}
+
+#[test]
+fn m3_split_matches_fused_bit_identical_bf16() {
+    run_split_vs_fused(WeightDtype::Bf16);
+}
+
+/// Interlock + accumulation window semantics (F32).
+#[test]
+fn m3_split_interlock_and_accumulate_window() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    let mut t = Mamba3Trainer::new_full(
+        0,
+        &w,
+        cfg.clone(),
+        session(batch, seq_len, input_dim),
+        WeightDtype::F32,
+    )
+    .expect("trainer");
+
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+    let input = det(n_in, 0xAA, 0.05);
+    let d_temporal = det(n_out, 0xBB, 0.01);
+    let mut out = vec![0.0f32; n_out];
+
+    // Backward with no pending forward -> Err.
+    assert!(
+        t.backward_step(&d_temporal, BackwardOpts::default())
+            .is_err()
+    );
+
+    // Open an accumulation window.
+    t.forward(&input, &mut out).expect("forward");
+    let m = t
+        .backward_step(
+            &d_temporal,
+            BackwardOpts::default().with_accumulate_only(true),
+        )
+        .expect("accumulate backward");
+    assert!(!m.optimizer_stepped);
+    assert_eq!(m.step, 0, "accumulate-only must not advance adam");
+
+    // Fused step must refuse while the window is open.
+    assert!(t.step(&input, &d_temporal).is_err());
+
+    // A second backward needs its own forward.
+    assert!(
+        t.backward_step(&d_temporal, BackwardOpts::default())
+            .is_err()
+    );
+
+    // Close the window with a clip; the fused step works again.
+    t.forward(&input, &mut out).expect("forward 2");
+    let m2 = t
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1.0))
+        .expect("closing backward");
+    assert!(m2.optimizer_stepped);
+    assert_eq!(m2.step, 1);
+    let norm = m2.grad_norm.expect("clip requested -> norm reported");
+    assert!(norm.is_finite() && norm > 0.0, "grad norm: {norm}");
+    t.step(&input, &d_temporal).expect("fused step after close");
+}
+
+/// f16 split: GradScaler protocol rides backward_step; accumulate_only errs.
+#[test]
+fn m3_f16_split_scaler_protocol() {
+    let cfg = test_cfg();
+    let input_dim = cfg.d_model;
+    let (batch, seq_len) = (1usize, 4usize);
+    let mut w = Mamba3Weights::init(&cfg, input_dim, 0xC0FFEE);
+    w.input_proj_w.clear();
+    w.input_proj_b.clear();
+    let mut t = Mamba3Trainer::new_full(
+        0,
+        &w,
+        cfg.clone(),
+        session(batch, seq_len, input_dim),
+        WeightDtype::F16,
+    )
+    .expect("f16 trainer");
+
+    let n_in = batch * seq_len * input_dim;
+    let n_out = batch * seq_len * cfg.d_model;
+    let input = det(n_in, 0xAC, 0.05);
+    let d_temporal = det(n_out, 0xBC, 0.01);
+    let mut out = vec![0.0f32; n_out];
+
+    t.forward(&input, &mut out).expect("forward");
+    assert!(
+        t.backward_step(
+            &d_temporal,
+            BackwardOpts::default().with_accumulate_only(true)
+        )
+        .is_err(),
+        "f16 + accumulate_only must be rejected"
+    );
+    // The rejected call must not have consumed the pending forward.
+    let m = t
+        .backward_step(&d_temporal, BackwardOpts::default().with_clip_max_norm(1.0))
+        .expect("f16 backward");
+    assert!(m.loss_scale.is_some());
+    assert!(m.overflow_skipped.is_some());
+    if m.optimizer_stepped {
+        let norm = m.grad_norm.expect("clean step reports the norm");
+        assert!(norm.is_finite() && norm > 0.0);
+    }
+}


### PR DESCRIPTION
Feature release. All additive; the fused step() and every captured-graph path are byte-untouched (pinned by split==fused bit-identity tests on both trainers).

- forward()/backward_step() split on MambaTrainer and Mamba3Trainer: full temporal readback, caller-side losses, deterministic global-norm clipping (one new kernel), exact gradient accumulation, f16 GradScaler protocol
- full-sequence CPU prefill for both architectures (prefill-then-decode, every phase parallel in PrefillMode::Parallel, bit-equal to the training forward)
- set_lr / drop_graph, reference-faithful AdamW no-decay groups (default off, bit-preserving)
- trainable bf16/f16 input_proj (mixed trainer)
- fix: matvec_bi faulted on arbitrary K (odd per-warp span + row alignment); dead da_exp activation buffer removed (~0.9 GB/layer at vision shapes)
- MSRV 1.97; cudarc 0.19.8, safetensors 0.8, hf-hub 1.0, tokenizers 0.23
- docs: 0.5.0 changelog with the name-and-defer table, README feature matrix + quick starts, two new examples

Full details in CHANGELOG.md. GPU suites verified on a 5090 (fresh-process, --test-threads=1): trainer_split 15/15, trainer_split_m3 4/4, grad_clip 6/6, parity walks, determinism 5/5, typed-parity incl. classifier shapes, model binaries green.